### PR TITLE
infra: add thea-director to CI/release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
-      - run: uv run --extra dev pytest tests/ -v --ignore=tests/e2e
+      - run: uv run --extra dev pytest tests/ -v --ignore=tests/e2e --ignore=tests/e2e-apps
+
+  director:
+    name: Director Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: cd director && uv run --extra dev python3 -m pytest tests/ -v
 
   go:
     name: Go SDK Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       next_version: ${{ steps.bump.outputs.next_version }}
       bump_type: ${{ steps.bump.outputs.bump_type }}
       python_changed: ${{ steps.changes.outputs.python }}
+      director_changed: ${{ steps.changes.outputs.director }}
       go_changed: ${{ steps.changes.outputs.go }}
       changelog: ${{ steps.changelog.outputs.text }}
     steps:
@@ -94,6 +95,15 @@ jobs:
           else
             echo "python=false" >> "$GITHUB_OUTPUT"
             echo "Python package unchanged — will skip publish"
+          fi
+
+          # Director package
+          if echo "$CHANGED" | grep -qE '^director/'; then
+            echo "director=true" >> "$GITHUB_OUTPUT"
+            echo "Director package changed"
+          else
+            echo "director=false" >> "$GITHUB_OUTPUT"
+            echo "Director package unchanged — will skip publish"
           fi
 
           # Go SDK
@@ -222,6 +232,24 @@ jobs:
       - uses: astral-sh/setup-uv@v4
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  director:
+    name: Publish Director to PyPI
+    needs: [check, release]
+    if: needs.check.outputs.director_changed == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.release.outputs.version }}
+      - uses: astral-sh/setup-uv@v4
+      - run: cd director && uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: director/dist/
 
   go:
     name: Publish Go SDK

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -16,6 +16,11 @@ echo "$VER" > "$ROOT/VERSION"
 # Python main package
 sed -i.bak "s/^version = \".*\"/version = \"$VER\"/" "$ROOT/pyproject.toml" && rm -f "$ROOT/pyproject.toml.bak"
 
+# Director package
+if [ -f "$ROOT/director/pyproject.toml" ]; then
+  sed -i.bak "s/^version = \".*\"/version = \"$VER\"/" "$ROOT/director/pyproject.toml" && rm -f "$ROOT/director/pyproject.toml.bak"
+fi
+
 # Python SDK
 sed -i.bak "s/^version = \".*\"/version = \"$VER\"/" "$ROOT/sdks/python/pyproject.toml" && rm -f "$ROOT/sdks/python/pyproject.toml.bak"
 


### PR DESCRIPTION
## Summary

- Fix CI failure: exclude `tests/e2e-apps/` (was only excluding `tests/e2e/`)
- Add Director test job to CI
- Add thea-director to release pipeline (detect changes, publish to PyPI)
- Include `director/pyproject.toml` in version bump script

## Test plan

- [ ] CI passes with the e2e-apps exclusion fix
- [ ] Director tests run in CI
- [ ] Next release publishes thea-director to PyPI when `director/` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)