### PR TITLE
feat: add [director] optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,14 @@ thea = "thea.cli:main"
 
 [project.optional-dependencies]
 server = ["flask>=3.0"]
-dev = ["pytest", "flask>=3.0"]
+director = ["thea-director"]
+dev = ["pytest", "flask>=3.0", "thea-director"]
 
 [project.urls]
 Homepage = "https://github.com/BarkingIguana/thea"
+
+[tool.uv.sources]
+thea-director = { path = "director/", editable = true }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/thea/recorder.py
+++ b/src/thea/recorder.py
@@ -104,6 +104,7 @@ class Recorder:
         self._allocated_bar_height = PANEL_HEIGHT
         self._panels = {}  # name -> {"title": str, "path": str, "width": int|None, "height": int|None}
         self._launched_apps = []  # Popen instances launched via launch_app()
+        self._director = None  # Lazy-initialised Director instance
 
     # -- Display -----------------------------------------------------------
 
@@ -169,6 +170,23 @@ class Recorder:
                 self._xvfb_proc.kill()
             self._xvfb_proc = None
             logger.debug("Xvfb stopped")
+
+    # -- Director ----------------------------------------------------------
+
+    @property
+    def director(self):
+        """A :class:`thea_director.Director` for human-like interaction on this display.
+
+        Requires ``pip install thea-recorder[director]``.  The Director
+        is created lazily on first access and reused thereafter.
+
+        Raises:
+            ImportError: If thea-director is not installed.
+        """
+        if self._director is None:
+            from thea_director import Director
+            self._director = Director(self.display_env)
+        return self._director
 
     # -- Application launching ---------------------------------------------
 

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -255,6 +255,48 @@ class TestLaunchApp:
             p.terminate.assert_called_once()
 
 
+class TestDirectorProperty:
+    def test_director_raises_without_package(self):
+        r = Recorder(display=42)
+        with patch.dict("sys.modules", {"thea_director": None}):
+            with pytest.raises(ImportError):
+                r.director
+
+    @patch("thea.recorder.subprocess.run")
+    def test_director_returns_director_instance(self, mock_run):
+        mock_run.return_value = Mock(stdout="window id # 0x1", returncode=0)
+        r = Recorder(display=42)
+        try:
+            from thea_director import Director
+        except ImportError:
+            pytest.skip("thea-director not installed")
+        d = r.director
+        assert isinstance(d, Director)
+
+    @patch("thea.recorder.subprocess.run")
+    def test_director_is_cached(self, mock_run):
+        mock_run.return_value = Mock(stdout="window id # 0x1", returncode=0)
+        r = Recorder(display=42)
+        try:
+            from thea_director import Director
+        except ImportError:
+            pytest.skip("thea-director not installed")
+        d1 = r.director
+        d2 = r.director
+        assert d1 is d2
+
+    @patch("thea.recorder.subprocess.run")
+    def test_director_uses_recorder_display(self, mock_run):
+        mock_run.return_value = Mock(stdout="window id # 0x1", returncode=0)
+        r = Recorder(display=77)
+        try:
+            from thea_director import Director
+        except ImportError:
+            pytest.skip("thea-director not installed")
+        d = r.director
+        assert d.env["DISPLAY"] == ":77"
+
+
 class TestPanels:
     def test_add_panel_creates_temp_file(self):
         r = Recorder()

--- a/uv.lock
+++ b/uv.lock
@@ -222,8 +222,20 @@ wheels = [
 ]
 
 [[package]]
-name = "thea-recorder"
+name = "thea-director"
 version = "0.6.0"
+source = { editable = "director" }
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "selenium", marker = "extra == 'selenium'", specifier = ">=4.0" },
+]
+provides-extras = ["selenium", "dev"]
+
+[[package]]
+name = "thea-recorder"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -233,6 +245,10 @@ dependencies = [
 dev = [
     { name = "flask" },
     { name = "pytest" },
+    { name = "thea-director" },
+]
+director = [
+    { name = "thea-director" },
 ]
 server = [
     { name = "flask" },
@@ -244,8 +260,10 @@ requires-dist = [
     { name = "flask", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "flask", marker = "extra == 'server'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "thea-director", marker = "extra == 'dev'", editable = "director" },
+    { name = "thea-director", marker = "extra == 'director'", editable = "director" },
 ]
-provides-extras = ["server", "dev"]
+provides-extras = ["server", "director", "dev"]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
## Summary

- Add `director` optional dependency: `pip install thea-recorder[director]`
- Add lazy `Recorder.director` property that creates a Director bound to the recorder's display
- Combinable with other extras: `pip install thea-recorder[server,director]`
- Local dev uses `[tool.uv.sources]` to resolve thea-director from `director/`

## Test plan

- [x] 318 tests pass (including 4 new director property tests)
- [x] ImportError raised when thea-director not installed
- [x] Director instance is cached and uses correct display

🤖 Generated with [Claude Code](https://claude.com/claude-code)