### PR TITLE
feat: Director HTTP API, client methods, and CLI commands

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -386,6 +386,215 @@ continue to work as before and operate on the **default** session.
 
 See [Orchestration guide](orchestration.md) for parallel recording examples.
 
+## Director (Human-like Interaction)
+
+The Director endpoints let you simulate human-like mouse, keyboard, and window
+interactions on the virtual display.  Mouse movements follow minimum-jerk
+trajectories; typing uses realistic rhythm models.
+
+All Director endpoints are available under both `/director/...` (default
+session) and `/sessions/{name}/director/...` (named session).
+
+### Mouse
+
+#### Move mouse
+```bash
+curl -X POST http://localhost:9123/director/mouse/move \
+  -H "Content-Type: application/json" \
+  -d '{"x": 500, "y": 300}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `x` | yes | Target X coordinate |
+| `y` | yes | Target Y coordinate |
+| `duration` | no | Movement duration in seconds (default: Fitts's Law estimate) |
+| `target_width` | no | Target element width for Fitts's Law calculation |
+
+**Response** `200`: `{"status": "ok"}`
+
+#### Click
+```bash
+curl -X POST http://localhost:9123/director/mouse/click \
+  -H "Content-Type: application/json" \
+  -d '{"x": 500, "y": 300}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `x` | no | X coordinate (omit to click in place) |
+| `y` | no | Y coordinate (omit to click in place) |
+| `button` | no | Mouse button: 1=left, 2=middle, 3=right (default: 1) |
+| `duration` | no | Movement duration in seconds |
+
+**Response** `200`: `{"status": "ok"}`
+
+#### Double-click
+```bash
+curl -X POST http://localhost:9123/director/mouse/double-click \
+  -H "Content-Type: application/json" \
+  -d '{"x": 500, "y": 300}'
+```
+Optional `x`, `y` fields. **Response** `200`: `{"status": "ok"}`
+
+#### Right-click
+```bash
+curl -X POST http://localhost:9123/director/mouse/right-click \
+  -H "Content-Type: application/json" \
+  -d '{"x": 500, "y": 300}'
+```
+Optional `x`, `y` fields. **Response** `200`: `{"status": "ok"}`
+
+#### Drag
+```bash
+curl -X POST http://localhost:9123/director/mouse/drag \
+  -H "Content-Type: application/json" \
+  -d '{"start_x": 100, "start_y": 200, "end_x": 500, "end_y": 400}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `start_x` | yes | Start X |
+| `start_y` | yes | Start Y |
+| `end_x` | yes | End X |
+| `end_y` | yes | End Y |
+| `button` | no | Mouse button (default: 1) |
+| `duration` | no | Drag duration in seconds |
+
+**Response** `200`: `{"status": "ok"}`
+
+#### Scroll
+```bash
+curl -X POST http://localhost:9123/director/mouse/scroll \
+  -H "Content-Type: application/json" \
+  -d '{"clicks": 3}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `clicks` | yes | Scroll clicks (positive=up, negative=down) |
+| `x` | no | X coordinate |
+| `y` | no | Y coordinate |
+
+**Response** `200`: `{"status": "ok"}`
+
+#### Get mouse position
+```bash
+curl http://localhost:9123/director/mouse/position
+```
+**Response** `200`: `{"x": 500, "y": 300}`
+
+### Keyboard
+
+#### Type text
+```bash
+curl -X POST http://localhost:9123/director/keyboard/type \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello, world!"}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `text` | yes | Text to type |
+| `wpm` | no | Typing speed in words per minute (default: realistic rhythm model) |
+
+**Response** `200`: `{"status": "ok"}`
+
+#### Press keys
+```bash
+curl -X POST http://localhost:9123/director/keyboard/press \
+  -H "Content-Type: application/json" \
+  -d '{"keys": ["ctrl+a", "Delete"]}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `keys` | yes | Array of key names (e.g. `["Return"]`, `["ctrl+c"]`) |
+
+**Response** `200`: `{"status": "ok"}`
+
+#### Hold key
+```bash
+curl -X POST http://localhost:9123/director/keyboard/hold \
+  -H "Content-Type: application/json" \
+  -d '{"key": "Shift_L"}'
+```
+**Response** `200`: `{"status": "ok"}`
+
+#### Release key
+```bash
+curl -X POST http://localhost:9123/director/keyboard/release \
+  -H "Content-Type: application/json" \
+  -d '{"key": "Shift_L"}'
+```
+**Response** `200`: `{"status": "ok"}`
+
+### Window Management
+
+#### Find window
+```bash
+curl -X POST http://localhost:9123/director/window/find \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Firefox"}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | one of `name`/`class` | Window title substring |
+| `class` | one of `name`/`class` | Window class |
+| `timeout` | no | Search timeout in seconds (default: 10) |
+
+**Response** `200`: `{"window_id": "12345"}`
+**Error** `404` if window not found within timeout.
+
+#### Focus window
+```bash
+curl -X POST http://localhost:9123/director/window/12345/focus
+```
+**Response** `200`: `{"status": "ok"}`
+
+#### Move window
+```bash
+curl -X POST http://localhost:9123/director/window/12345/move \
+  -H "Content-Type: application/json" \
+  -d '{"x": 0, "y": 0}'
+```
+**Response** `200`: `{"status": "ok"}`
+
+#### Resize window
+```bash
+curl -X POST http://localhost:9123/director/window/12345/resize \
+  -H "Content-Type: application/json" \
+  -d '{"width": 1280, "height": 720}'
+```
+**Response** `200`: `{"status": "ok"}`
+
+#### Minimize window
+```bash
+curl -X POST http://localhost:9123/director/window/12345/minimize
+```
+**Response** `200`: `{"status": "ok"}`
+
+#### Get window geometry
+```bash
+curl http://localhost:9123/director/window/12345/geometry
+```
+**Response** `200`: `{"x": 0, "y": 0, "width": 1280, "height": 720}`
+
+#### Tile windows
+```bash
+curl -X POST http://localhost:9123/director/window/tile \
+  -H "Content-Type: application/json" \
+  -d '{"window_ids": ["111", "222"], "layout": "side-by-side"}'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `window_ids` | yes | Array of window ID strings |
+| `layout` | no | `side-by-side`, `stacked`, or `grid` (default: `side-by-side`) |
+
+**Response** `200`: `{"status": "ok"}`
+
 ## Thread Safety
 
 All endpoints that mutate recorder state are protected by a `threading.Lock`. Concurrent callers (e.g., multiple SDK clients or panel updates from different threads) are safe.

--- a/src/thea/cli.py
+++ b/src/thea/cli.py
@@ -567,3 +567,358 @@ def multi(instances, base_port, base_display, output_dir, default_display_size, 
             proc.wait()
     except KeyboardInterrupt:
         _stop_all()
+
+
+# ── Director: Mouse commands ─────────────────────────────────────────────
+
+@main.command("mouse-move")
+@click.option("--x", required=True, type=int, help="Target X coordinate.")
+@click.option("--y", required=True, type=int, help="Target Y coordinate.")
+@click.option("--duration", default=None, type=float, help="Movement duration in seconds.")
+@click.option("--target-width", default=None, type=int, help="Target element width for Fitts's Law.")
+@click.pass_context
+def mouse_move(ctx, x, y, duration, target_width):
+    """Move the mouse cursor to (x, y) with human-like motion."""
+    server = _server_url(ctx)
+    body = {"x": x, "y": y}
+    if duration is not None:
+        body["duration"] = duration
+    if target_width is not None:
+        body["target_width"] = target_width
+    try:
+        status, data = _request(f"{server}/director/mouse/move", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("mouse-click")
+@click.option("--x", default=None, type=int, help="X coordinate (omit to click in place).")
+@click.option("--y", default=None, type=int, help="Y coordinate (omit to click in place).")
+@click.option("--button", default=1, type=int, help="Mouse button (1=left, 2=middle, 3=right).")
+@click.option("--duration", default=None, type=float, help="Movement duration in seconds.")
+@click.pass_context
+def mouse_click(ctx, x, y, button, duration):
+    """Click the mouse at (x, y) or in place."""
+    server = _server_url(ctx)
+    body = {"button": button}
+    if x is not None:
+        body["x"] = x
+    if y is not None:
+        body["y"] = y
+    if duration is not None:
+        body["duration"] = duration
+    try:
+        status, data = _request(f"{server}/director/mouse/click", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("mouse-double-click")
+@click.option("--x", default=None, type=int, help="X coordinate.")
+@click.option("--y", default=None, type=int, help="Y coordinate.")
+@click.pass_context
+def mouse_double_click(ctx, x, y):
+    """Double-click at (x, y) or in place."""
+    server = _server_url(ctx)
+    body = {}
+    if x is not None:
+        body["x"] = x
+    if y is not None:
+        body["y"] = y
+    try:
+        status, data = _request(f"{server}/director/mouse/double-click", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("mouse-right-click")
+@click.option("--x", default=None, type=int, help="X coordinate.")
+@click.option("--y", default=None, type=int, help="Y coordinate.")
+@click.pass_context
+def mouse_right_click(ctx, x, y):
+    """Right-click at (x, y) or in place."""
+    server = _server_url(ctx)
+    body = {}
+    if x is not None:
+        body["x"] = x
+    if y is not None:
+        body["y"] = y
+    try:
+        status, data = _request(f"{server}/director/mouse/right-click", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("mouse-drag")
+@click.option("--start-x", required=True, type=int, help="Start X.")
+@click.option("--start-y", required=True, type=int, help="Start Y.")
+@click.option("--end-x", required=True, type=int, help="End X.")
+@click.option("--end-y", required=True, type=int, help="End Y.")
+@click.option("--button", default=1, type=int, help="Mouse button.")
+@click.option("--duration", default=None, type=float, help="Drag duration in seconds.")
+@click.pass_context
+def mouse_drag(ctx, start_x, start_y, end_x, end_y, button, duration):
+    """Drag from (start-x, start-y) to (end-x, end-y)."""
+    server = _server_url(ctx)
+    body = {"start_x": start_x, "start_y": start_y, "end_x": end_x, "end_y": end_y, "button": button}
+    if duration is not None:
+        body["duration"] = duration
+    try:
+        status, data = _request(f"{server}/director/mouse/drag", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("mouse-scroll")
+@click.option("--clicks", required=True, type=int, help="Scroll clicks (positive=up, negative=down).")
+@click.option("--x", default=None, type=int, help="X coordinate.")
+@click.option("--y", default=None, type=int, help="Y coordinate.")
+@click.pass_context
+def mouse_scroll(ctx, clicks, x, y):
+    """Scroll the mouse wheel."""
+    server = _server_url(ctx)
+    body = {"clicks": clicks}
+    if x is not None:
+        body["x"] = x
+    if y is not None:
+        body["y"] = y
+    try:
+        status, data = _request(f"{server}/director/mouse/scroll", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("mouse-position")
+@click.pass_context
+def mouse_position(ctx):
+    """Get the current mouse cursor position."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/mouse/position")
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+# ── Director: Keyboard commands ──────────────────────────────────────────
+
+@main.command("keyboard-type")
+@click.argument("text")
+@click.option("--wpm", default=None, type=int, help="Typing speed in words per minute.")
+@click.pass_context
+def keyboard_type(ctx, text, wpm):
+    """Type text with human-like rhythm."""
+    server = _server_url(ctx)
+    body = {"text": text}
+    if wpm is not None:
+        body["wpm"] = wpm
+    try:
+        status, data = _request(f"{server}/director/keyboard/type", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("keyboard-press")
+@click.argument("keys", nargs=-1, required=True)
+@click.pass_context
+def keyboard_press(ctx, keys):
+    """Press one or more keys (e.g. Return, ctrl+a, Delete)."""
+    server = _server_url(ctx)
+    body = {"keys": list(keys)}
+    try:
+        status, data = _request(f"{server}/director/keyboard/press", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("keyboard-hold")
+@click.argument("key")
+@click.pass_context
+def keyboard_hold(ctx, key):
+    """Hold a key down (release with keyboard-release)."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/keyboard/hold", method="POST", data={"key": key})
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("keyboard-release")
+@click.argument("key")
+@click.pass_context
+def keyboard_release(ctx, key):
+    """Release a held key."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/keyboard/release", method="POST", data={"key": key})
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+# ── Director: Window commands ────────────────────────────────────────────
+
+@main.command("window-find")
+@click.option("--name", default=None, help="Window name/title substring.")
+@click.option("--class", "window_class", default=None, help="Window class.")
+@click.option("--timeout", default=10.0, type=float, help="Search timeout in seconds.")
+@click.pass_context
+def window_find(ctx, name, window_class, timeout):
+    """Find a window by name or class."""
+    server = _server_url(ctx)
+    body = {"timeout": timeout}
+    if name is not None:
+        body["name"] = name
+    elif window_class is not None:
+        body["class"] = window_class
+    else:
+        click.echo("Error: --name or --class is required", err=True)
+        sys.exit(1)
+    try:
+        status, data = _request(f"{server}/director/window/find", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("window-focus")
+@click.argument("window_id")
+@click.pass_context
+def window_focus(ctx, window_id):
+    """Focus a window by ID."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/window/{window_id}/focus", method="POST")
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("window-move")
+@click.argument("window_id")
+@click.option("--x", required=True, type=int, help="X position.")
+@click.option("--y", required=True, type=int, help="Y position.")
+@click.pass_context
+def window_move(ctx, window_id, x, y):
+    """Move a window to (x, y)."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/window/{window_id}/move", method="POST", data={"x": x, "y": y})
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("window-resize")
+@click.argument("window_id")
+@click.option("--width", required=True, type=int, help="Width in pixels.")
+@click.option("--height", required=True, type=int, help="Height in pixels.")
+@click.pass_context
+def window_resize(ctx, window_id, width, height):
+    """Resize a window."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/window/{window_id}/resize", method="POST", data={"width": width, "height": height})
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("window-minimize")
+@click.argument("window_id")
+@click.pass_context
+def window_minimize(ctx, window_id):
+    """Minimize a window."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/window/{window_id}/minimize", method="POST")
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("window-geometry")
+@click.argument("window_id")
+@click.pass_context
+def window_geometry(ctx, window_id):
+    """Get window position and size."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/director/window/{window_id}/geometry")
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("window-tile")
+@click.option("--ids", required=True, help="Comma-separated window IDs.")
+@click.option("--layout", default="side-by-side", type=click.Choice(["side-by-side", "stacked", "grid"]),
+              help="Tile layout.")
+@click.pass_context
+def window_tile(ctx, ids, layout):
+    """Tile multiple windows in the display."""
+    server = _server_url(ctx)
+    window_ids = [i.strip() for i in ids.split(",") if i.strip()]
+    try:
+        status, data = _request(f"{server}/director/window/tile", method="POST",
+                                data={"window_ids": window_ids, "layout": layout})
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])

--- a/src/thea/client.py
+++ b/src/thea/client.py
@@ -617,6 +617,131 @@ class RecorderClient:
         helper.result = self.wait_for_composition(name)
 
     # ------------------------------------------------------------------
+    # Director — Mouse
+    # ------------------------------------------------------------------
+
+    def mouse_move(self, x: int, y: int, *, duration: float | None = None, target_width: float | None = None) -> dict[str, Any]:
+        """POST /director/mouse/move — move the mouse cursor."""
+        body: dict[str, Any] = {"x": x, "y": y}
+        if duration is not None:
+            body["duration"] = duration
+        if target_width is not None:
+            body["target_width"] = target_width
+        return self._request("POST", "/director/mouse/move", body)
+
+    def mouse_click(self, x: int | None = None, y: int | None = None, *, button: int = 1, duration: float | None = None) -> dict[str, Any]:
+        """POST /director/mouse/click — click the mouse."""
+        body: dict[str, Any] = {"button": button}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        if duration is not None:
+            body["duration"] = duration
+        return self._request("POST", "/director/mouse/click", body)
+
+    def mouse_double_click(self, x: int | None = None, y: int | None = None) -> dict[str, Any]:
+        """POST /director/mouse/double-click — double-click."""
+        body: dict[str, Any] = {}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        return self._request("POST", "/director/mouse/double-click", body)
+
+    def mouse_right_click(self, x: int | None = None, y: int | None = None) -> dict[str, Any]:
+        """POST /director/mouse/right-click — right-click."""
+        body: dict[str, Any] = {}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        return self._request("POST", "/director/mouse/right-click", body)
+
+    def mouse_drag(self, start_x: int, start_y: int, end_x: int, end_y: int, *, button: int = 1, duration: float | None = None) -> dict[str, Any]:
+        """POST /director/mouse/drag — drag from one point to another."""
+        body: dict[str, Any] = {"start_x": start_x, "start_y": start_y, "end_x": end_x, "end_y": end_y, "button": button}
+        if duration is not None:
+            body["duration"] = duration
+        return self._request("POST", "/director/mouse/drag", body)
+
+    def mouse_scroll(self, clicks: int, *, x: int | None = None, y: int | None = None) -> dict[str, Any]:
+        """POST /director/mouse/scroll — scroll the mouse wheel."""
+        body: dict[str, Any] = {"clicks": clicks}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        return self._request("POST", "/director/mouse/scroll", body)
+
+    def mouse_position(self) -> dict[str, Any]:
+        """GET /director/mouse/position — get cursor position."""
+        return self._request("GET", "/director/mouse/position")
+
+    # ------------------------------------------------------------------
+    # Director — Keyboard
+    # ------------------------------------------------------------------
+
+    def keyboard_type(self, text: str, *, wpm: float | None = None) -> dict[str, Any]:
+        """POST /director/keyboard/type — type text with human-like rhythm."""
+        body: dict[str, Any] = {"text": text}
+        if wpm is not None:
+            body["wpm"] = wpm
+        return self._request("POST", "/director/keyboard/type", body)
+
+    def keyboard_press(self, *keys: str) -> dict[str, Any]:
+        """POST /director/keyboard/press — press key(s)."""
+        return self._request("POST", "/director/keyboard/press", {"keys": list(keys)})
+
+    def keyboard_hold(self, key: str) -> dict[str, Any]:
+        """POST /director/keyboard/hold — hold a key down."""
+        return self._request("POST", "/director/keyboard/hold", {"key": key})
+
+    def keyboard_release(self, key: str) -> dict[str, Any]:
+        """POST /director/keyboard/release — release a held key."""
+        return self._request("POST", "/director/keyboard/release", {"key": key})
+
+    # ------------------------------------------------------------------
+    # Director — Window
+    # ------------------------------------------------------------------
+
+    def window_find(self, name: str | None = None, *, class_name: str | None = None, timeout: float = 10.0) -> dict[str, Any]:
+        """POST /director/window/find — find a window by name or WM_CLASS."""
+        body: dict[str, Any] = {"timeout": timeout}
+        if name is not None:
+            body["name"] = name
+        if class_name is not None:
+            body["class"] = class_name
+        return self._request("POST", "/director/window/find", body)
+
+    def window_focus(self, window_id: str) -> dict[str, Any]:
+        """POST /director/window/{id}/focus — focus a window."""
+        return self._request("POST", f"/director/window/{window_id}/focus")
+
+    def window_move(self, window_id: str, x: int, y: int) -> dict[str, Any]:
+        """POST /director/window/{id}/move — move a window."""
+        return self._request("POST", f"/director/window/{window_id}/move", {"x": x, "y": y})
+
+    def window_resize(self, window_id: str, width: int, height: int) -> dict[str, Any]:
+        """POST /director/window/{id}/resize — resize a window."""
+        return self._request("POST", f"/director/window/{window_id}/resize", {"width": width, "height": height})
+
+    def window_minimize(self, window_id: str) -> dict[str, Any]:
+        """POST /director/window/{id}/minimize — minimize a window."""
+        return self._request("POST", f"/director/window/{window_id}/minimize")
+
+    def window_geometry(self, window_id: str) -> dict[str, Any]:
+        """GET /director/window/{id}/geometry — get window geometry."""
+        return self._request("GET", f"/director/window/{window_id}/geometry")
+
+    def window_tile(self, window_ids: list[str], layout: str = "side-by-side", *, bounds: tuple[int, int, int, int] | None = None) -> dict[str, Any]:
+        """POST /director/window/tile — tile windows."""
+        body: dict[str, Any] = {"window_ids": window_ids, "layout": layout}
+        if bounds is not None:
+            body["bounds"] = list(bounds)
+        return self._request("POST", "/director/window/tile", body)
+
+    # ------------------------------------------------------------------
     # Convenience helpers
     # ------------------------------------------------------------------
 

--- a/src/thea/server.py
+++ b/src/thea/server.py
@@ -681,6 +681,372 @@ def create_app(
     # Expose for testing
     app._composer = _composer
 
+    # ── Director endpoints ─────────────────────────────────────────────────
+
+    def _impl_director_mouse_move(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        x = data.get("x")
+        y = data.get("y")
+        if x is None or y is None:
+            return jsonify({"error": "fields 'x' and 'y' are required"}), 400
+        duration = data.get("duration")
+        target_width = data.get("target_width")
+        with sess_lock:
+            rec.director.mouse.move_to(int(x), int(y), duration=duration, target_width=target_width)
+        return jsonify({"status": "ok", "x": int(x), "y": int(y)}), 200
+
+    def _impl_director_mouse_click(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        x = data.get("x")
+        y = data.get("y")
+        button = data.get("button", 1)
+        duration = data.get("duration")
+        with sess_lock:
+            rec.director.mouse.click(
+                int(x) if x is not None else None,
+                int(y) if y is not None else None,
+                button=int(button),
+                duration=duration,
+            )
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_mouse_double_click(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        x = data.get("x")
+        y = data.get("y")
+        duration = data.get("duration")
+        with sess_lock:
+            rec.director.mouse.double_click(
+                int(x) if x is not None else None,
+                int(y) if y is not None else None,
+                duration=duration,
+            )
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_mouse_right_click(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        x = data.get("x")
+        y = data.get("y")
+        duration = data.get("duration")
+        with sess_lock:
+            rec.director.mouse.right_click(
+                int(x) if x is not None else None,
+                int(y) if y is not None else None,
+                duration=duration,
+            )
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_mouse_drag(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        for field in ("start_x", "start_y", "end_x", "end_y"):
+            if data.get(field) is None:
+                return jsonify({"error": f"field '{field}' is required"}), 400
+        button = data.get("button", 1)
+        duration = data.get("duration")
+        with sess_lock:
+            rec.director.mouse.drag(
+                int(data["start_x"]), int(data["start_y"]),
+                int(data["end_x"]), int(data["end_y"]),
+                button=int(button), duration=duration,
+            )
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_mouse_scroll(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        clicks = data.get("clicks")
+        if clicks is None:
+            return jsonify({"error": "field 'clicks' is required"}), 400
+        x = data.get("x")
+        y = data.get("y")
+        with sess_lock:
+            rec.director.mouse.scroll(
+                int(clicks),
+                x=int(x) if x is not None else None,
+                y=int(y) if y is not None else None,
+            )
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_mouse_position(rec, sess_lock):
+        with sess_lock:
+            x, y = rec.director.mouse.position()
+        return jsonify({"x": x, "y": y}), 200
+
+    def _impl_director_keyboard_type(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        text = data.get("text")
+        if text is None:
+            return jsonify({"error": "field 'text' is required"}), 400
+        wpm = data.get("wpm")
+        with sess_lock:
+            rec.director.keyboard.type(str(text), wpm=wpm)
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_keyboard_press(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        keys = data.get("keys")
+        if not keys or not isinstance(keys, list):
+            return jsonify({"error": "field 'keys' must be a non-empty list of key names"}), 400
+        with sess_lock:
+            rec.director.keyboard.press(*keys)
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_keyboard_hold(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        key = data.get("key")
+        if not key:
+            return jsonify({"error": "field 'key' is required"}), 400
+        with sess_lock:
+            rec.director.keyboard.hold(str(key))
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_keyboard_release(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        key = data.get("key")
+        if not key:
+            return jsonify({"error": "field 'key' is required"}), 400
+        with sess_lock:
+            rec.director.keyboard.release(str(key))
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_window_find(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        name = data.get("name")
+        class_name = data.get("class")
+        if not name and not class_name:
+            return jsonify({"error": "field 'name' or 'class' is required"}), 400
+        timeout = data.get("timeout", 10.0)
+        with sess_lock:
+            try:
+                if class_name:
+                    win = rec.director.window_by_class(str(class_name), timeout=float(timeout))
+                else:
+                    win = rec.director.window(str(name), timeout=float(timeout))
+            except RuntimeError as e:
+                return jsonify({"error": str(e)}), 404
+        return jsonify({"window_id": win.id}), 200
+
+    def _impl_director_window_focus(rec, sess_lock, window_id):
+        from .director.window import Window
+        with sess_lock:
+            Window(window_id, rec.director.env).focus()
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_window_move(rec, sess_lock, window_id):
+        data = request.get_json(silent=True) or {}
+        x = data.get("x")
+        y = data.get("y")
+        if x is None or y is None:
+            return jsonify({"error": "fields 'x' and 'y' are required"}), 400
+        from .director.window import Window
+        with sess_lock:
+            Window(window_id, rec.director.env).move(int(x), int(y))
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_window_resize(rec, sess_lock, window_id):
+        data = request.get_json(silent=True) or {}
+        width = data.get("width")
+        height = data.get("height")
+        if width is None or height is None:
+            return jsonify({"error": "fields 'width' and 'height' are required"}), 400
+        from .director.window import Window
+        with sess_lock:
+            Window(window_id, rec.director.env).resize(int(width), int(height))
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_window_minimize(rec, sess_lock, window_id):
+        from .director.window import Window
+        with sess_lock:
+            Window(window_id, rec.director.env).minimize()
+        return jsonify({"status": "ok"}), 200
+
+    def _impl_director_window_geometry(rec, sess_lock, window_id):
+        from .director.window import Window
+        with sess_lock:
+            x, y, w, h = Window(window_id, rec.director.env).geometry
+        return jsonify({"x": x, "y": y, "width": w, "height": h}), 200
+
+    def _impl_director_window_tile(rec, sess_lock):
+        data = request.get_json(silent=True) or {}
+        window_ids = data.get("window_ids")
+        if not window_ids or not isinstance(window_ids, list):
+            return jsonify({"error": "field 'window_ids' must be a non-empty list"}), 400
+        layout = data.get("layout", "side-by-side")
+        bounds = data.get("bounds")
+        from .director.window import Window, tile as tile_windows
+        with sess_lock:
+            windows = [Window(wid, rec.director.env) for wid in window_ids]
+            tile_windows(
+                windows, layout,
+                bounds=tuple(bounds) if bounds else None,
+            )
+        return jsonify({"status": "ok"}), 200
+
+    # -- Director: default session routes --
+
+    @app.route("/director/mouse/move", methods=["POST"])
+    def director_mouse_move():
+        return _impl_director_mouse_move(recorder, lock)
+
+    @app.route("/director/mouse/click", methods=["POST"])
+    def director_mouse_click():
+        return _impl_director_mouse_click(recorder, lock)
+
+    @app.route("/director/mouse/double-click", methods=["POST"])
+    def director_mouse_double_click():
+        return _impl_director_mouse_double_click(recorder, lock)
+
+    @app.route("/director/mouse/right-click", methods=["POST"])
+    def director_mouse_right_click():
+        return _impl_director_mouse_right_click(recorder, lock)
+
+    @app.route("/director/mouse/drag", methods=["POST"])
+    def director_mouse_drag():
+        return _impl_director_mouse_drag(recorder, lock)
+
+    @app.route("/director/mouse/scroll", methods=["POST"])
+    def director_mouse_scroll():
+        return _impl_director_mouse_scroll(recorder, lock)
+
+    @app.route("/director/mouse/position", methods=["GET"])
+    def director_mouse_position():
+        return _impl_director_mouse_position(recorder, lock)
+
+    @app.route("/director/keyboard/type", methods=["POST"])
+    def director_keyboard_type():
+        return _impl_director_keyboard_type(recorder, lock)
+
+    @app.route("/director/keyboard/press", methods=["POST"])
+    def director_keyboard_press():
+        return _impl_director_keyboard_press(recorder, lock)
+
+    @app.route("/director/keyboard/hold", methods=["POST"])
+    def director_keyboard_hold():
+        return _impl_director_keyboard_hold(recorder, lock)
+
+    @app.route("/director/keyboard/release", methods=["POST"])
+    def director_keyboard_release():
+        return _impl_director_keyboard_release(recorder, lock)
+
+    @app.route("/director/window/find", methods=["POST"])
+    def director_window_find():
+        return _impl_director_window_find(recorder, lock)
+
+    @app.route("/director/window/<window_id>/focus", methods=["POST"])
+    def director_window_focus(window_id):
+        return _impl_director_window_focus(recorder, lock, window_id)
+
+    @app.route("/director/window/<window_id>/move", methods=["POST"])
+    def director_window_move(window_id):
+        return _impl_director_window_move(recorder, lock, window_id)
+
+    @app.route("/director/window/<window_id>/resize", methods=["POST"])
+    def director_window_resize(window_id):
+        return _impl_director_window_resize(recorder, lock, window_id)
+
+    @app.route("/director/window/<window_id>/minimize", methods=["POST"])
+    def director_window_minimize(window_id):
+        return _impl_director_window_minimize(recorder, lock, window_id)
+
+    @app.route("/director/window/<window_id>/geometry", methods=["GET"])
+    def director_window_geometry(window_id):
+        return _impl_director_window_geometry(recorder, lock, window_id)
+
+    @app.route("/director/window/tile", methods=["POST"])
+    def director_window_tile():
+        return _impl_director_window_tile(recorder, lock)
+
+    # -- Director: session-scoped routes --
+
+    @app.route("/sessions/<session_name>/director/mouse/move", methods=["POST"])
+    def sess_director_mouse_move(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_mouse_move(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/mouse/click", methods=["POST"])
+    def sess_director_mouse_click(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_mouse_click(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/mouse/double-click", methods=["POST"])
+    def sess_director_mouse_double_click(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_mouse_double_click(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/mouse/right-click", methods=["POST"])
+    def sess_director_mouse_right_click(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_mouse_right_click(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/mouse/drag", methods=["POST"])
+    def sess_director_mouse_drag(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_mouse_drag(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/mouse/scroll", methods=["POST"])
+    def sess_director_mouse_scroll(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_mouse_scroll(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/mouse/position", methods=["GET"])
+    def sess_director_mouse_position(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_mouse_position(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/keyboard/type", methods=["POST"])
+    def sess_director_keyboard_type(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_keyboard_type(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/keyboard/press", methods=["POST"])
+    def sess_director_keyboard_press(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_keyboard_press(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/keyboard/hold", methods=["POST"])
+    def sess_director_keyboard_hold(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_keyboard_hold(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/keyboard/release", methods=["POST"])
+    def sess_director_keyboard_release(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_keyboard_release(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/window/find", methods=["POST"])
+    def sess_director_window_find(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_window_find(sess["recorder"], sess["lock"])
+
+    @app.route("/sessions/<session_name>/director/window/<window_id>/focus", methods=["POST"])
+    def sess_director_window_focus(session_name, window_id):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_window_focus(sess["recorder"], sess["lock"], window_id)
+
+    @app.route("/sessions/<session_name>/director/window/<window_id>/move", methods=["POST"])
+    def sess_director_window_move(session_name, window_id):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_window_move(sess["recorder"], sess["lock"], window_id)
+
+    @app.route("/sessions/<session_name>/director/window/<window_id>/resize", methods=["POST"])
+    def sess_director_window_resize(session_name, window_id):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_window_resize(sess["recorder"], sess["lock"], window_id)
+
+    @app.route("/sessions/<session_name>/director/window/<window_id>/minimize", methods=["POST"])
+    def sess_director_window_minimize(session_name, window_id):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_window_minimize(sess["recorder"], sess["lock"], window_id)
+
+    @app.route("/sessions/<session_name>/director/window/<window_id>/geometry", methods=["GET"])
+    def sess_director_window_geometry(session_name, window_id):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_window_geometry(sess["recorder"], sess["lock"], window_id)
+
+    @app.route("/sessions/<session_name>/director/window/tile", methods=["POST"])
+    def sess_director_window_tile(session_name):
+        sess, err = _session_or_404(session_name)
+        return err if err else _impl_director_window_tile(sess["recorder"], sess["lock"])
+
     # -- Graceful shutdown -------------------------------------------------
 
     def _shutdown_handler(signum, frame):

--- a/tests/test_server_director.py
+++ b/tests/test_server_director.py
@@ -1,0 +1,313 @@
+"""Tests for Director endpoints on the server."""
+
+import json
+from unittest.mock import patch, MagicMock, PropertyMock
+
+import pytest
+
+from thea.server import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app(output_dir="/tmp/test-recordings", enable_cors=False)
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _mock_director():
+    """Create a mock Director with mouse, keyboard, and window methods."""
+    d = MagicMock()
+    d.mouse = MagicMock()
+    d.mouse.position.return_value = (100, 200)
+    d.keyboard = MagicMock()
+    d.env = {"DISPLAY": ":99"}
+    return d
+
+
+class TestMouseMove:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_move(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/move", json={"x": 100, "y": 200})
+        assert resp.status_code == 200
+        d.mouse.move_to.assert_called_once_with(100, 200, duration=None, target_width=None)
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_move_with_duration(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/move", json={"x": 50, "y": 50, "duration": 0.3})
+        assert resp.status_code == 200
+        d.mouse.move_to.assert_called_once_with(50, 50, duration=0.3, target_width=None)
+
+    def test_move_missing_fields(self, client):
+        resp = client.post("/director/mouse/move", json={"x": 100})
+        assert resp.status_code == 400
+
+
+class TestMouseClick:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_click_at_position(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/click", json={"x": 100, "y": 200})
+        assert resp.status_code == 200
+        d.mouse.click.assert_called_once_with(100, 200, button=1, duration=None)
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_click_in_place(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/click", json={})
+        assert resp.status_code == 200
+        d.mouse.click.assert_called_once_with(None, None, button=1, duration=None)
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_click_custom_button(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/click", json={"x": 10, "y": 20, "button": 2})
+        assert resp.status_code == 200
+        d.mouse.click.assert_called_once_with(10, 20, button=2, duration=None)
+
+
+class TestMouseDoubleClick:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_double_click(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/double-click", json={"x": 100, "y": 200})
+        assert resp.status_code == 200
+        d.mouse.double_click.assert_called_once()
+
+
+class TestMouseRightClick:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_right_click(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/right-click", json={"x": 100, "y": 200})
+        assert resp.status_code == 200
+        d.mouse.right_click.assert_called_once()
+
+
+class TestMouseDrag:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_drag(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/drag", json={
+            "start_x": 10, "start_y": 20, "end_x": 300, "end_y": 400
+        })
+        assert resp.status_code == 200
+        d.mouse.drag.assert_called_once_with(10, 20, 300, 400, button=1, duration=None)
+
+    def test_drag_missing_fields(self, client):
+        resp = client.post("/director/mouse/drag", json={"start_x": 10})
+        assert resp.status_code == 400
+
+
+class TestMouseScroll:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_scroll(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/mouse/scroll", json={"clicks": 3})
+        assert resp.status_code == 200
+        d.mouse.scroll.assert_called_once_with(3, x=None, y=None)
+
+    def test_scroll_missing_clicks(self, client):
+        resp = client.post("/director/mouse/scroll", json={})
+        assert resp.status_code == 400
+
+
+class TestMousePosition:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_position(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.get("/director/mouse/position")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data == {"x": 100, "y": 200}
+
+
+class TestKeyboardType:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_type(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/keyboard/type", json={"text": "hello"})
+        assert resp.status_code == 200
+        d.keyboard.type.assert_called_once_with("hello", wpm=None)
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_type_with_wpm(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/keyboard/type", json={"text": "fast", "wpm": 120})
+        assert resp.status_code == 200
+        d.keyboard.type.assert_called_once_with("fast", wpm=120)
+
+    def test_type_missing_text(self, client):
+        resp = client.post("/director/keyboard/type", json={})
+        assert resp.status_code == 400
+
+
+class TestKeyboardPress:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_press(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/keyboard/press", json={"keys": ["Return"]})
+        assert resp.status_code == 200
+        d.keyboard.press.assert_called_once_with("Return")
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_press_multiple(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/keyboard/press", json={"keys": ["ctrl+a", "Delete"]})
+        assert resp.status_code == 200
+        d.keyboard.press.assert_called_once_with("ctrl+a", "Delete")
+
+    def test_press_missing_keys(self, client):
+        resp = client.post("/director/keyboard/press", json={})
+        assert resp.status_code == 400
+
+
+class TestKeyboardHoldRelease:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_hold(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/keyboard/hold", json={"key": "Shift_L"})
+        assert resp.status_code == 200
+        d.keyboard.hold.assert_called_once_with("Shift_L")
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_release(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/keyboard/release", json={"key": "Shift_L"})
+        assert resp.status_code == 200
+        d.keyboard.release.assert_called_once_with("Shift_L")
+
+    def test_hold_missing_key(self, client):
+        resp = client.post("/director/keyboard/hold", json={})
+        assert resp.status_code == 400
+
+    def test_release_missing_key(self, client):
+        resp = client.post("/director/keyboard/release", json={})
+        assert resp.status_code == 400
+
+
+class TestWindowFind:
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_find_by_name(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_win = MagicMock()
+        mock_win.id = "12345"
+        d.window.return_value = mock_win
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/find", json={"name": "Firefox"})
+        assert resp.status_code == 200
+        assert resp.get_json()["window_id"] == "12345"
+        d.window.assert_called_once_with("Firefox", timeout=10.0)
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_find_by_class(self, mock_director_prop, client):
+        d = _mock_director()
+        mock_win = MagicMock()
+        mock_win.id = "99999"
+        d.window_by_class.return_value = mock_win
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/find", json={"class": "chromium"})
+        assert resp.status_code == 200
+        assert resp.get_json()["window_id"] == "99999"
+
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_find_not_found(self, mock_director_prop, client):
+        d = _mock_director()
+        d.window.side_effect = RuntimeError("Window matching 'nope' not found within 1.0s")
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/find", json={"name": "nope", "timeout": 1.0})
+        assert resp.status_code == 404
+
+    def test_find_missing_fields(self, client):
+        resp = client.post("/director/window/find", json={})
+        assert resp.status_code == 400
+
+
+class TestWindowOperations:
+    @patch("thea.director.xdotool.window_focus")
+    @patch("thea.director.xdotool.window_activate")
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_focus(self, mock_director_prop, mock_activate, mock_focus, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/12345/focus")
+        assert resp.status_code == 200
+
+    @patch("thea.director.xdotool.window_move")
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_move(self, mock_director_prop, mock_move, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/12345/move", json={"x": 0, "y": 0})
+        assert resp.status_code == 200
+
+    @patch("thea.director.xdotool.window_resize")
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_resize(self, mock_director_prop, mock_resize, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/12345/resize", json={"width": 800, "height": 600})
+        assert resp.status_code == 200
+
+    @patch("thea.director.xdotool.window_minimize")
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_minimize(self, mock_director_prop, mock_minimize, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/12345/minimize")
+        assert resp.status_code == 200
+
+    @patch("thea.director.xdotool.window_get_geometry", return_value=(10, 20, 800, 600))
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_geometry(self, mock_director_prop, mock_geom, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.get("/director/window/12345/geometry")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data == {"x": 10, "y": 20, "width": 800, "height": 600}
+
+    def test_move_missing_fields(self, client):
+        resp = client.post("/director/window/12345/move", json={"x": 0})
+        assert resp.status_code == 400
+
+    def test_resize_missing_fields(self, client):
+        resp = client.post("/director/window/12345/resize", json={"width": 800})
+        assert resp.status_code == 400
+
+
+class TestWindowTile:
+    @patch("thea.director.window.tile")
+    @patch("thea.recorder.Recorder.director", new_callable=PropertyMock)
+    def test_tile(self, mock_director_prop, mock_tile, client):
+        d = _mock_director()
+        mock_director_prop.return_value = d
+        resp = client.post("/director/window/tile", json={
+            "window_ids": ["111", "222"], "layout": "side-by-side"
+        })
+        assert resp.status_code == 200
+
+    def test_tile_missing_ids(self, client):
+        resp = client.post("/director/window/tile", json={})
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- **Server**: 17 new REST endpoints under `/director/` for mouse (move, click, double-click, right-click, drag, scroll, position), keyboard (type, press, hold, release), and window management (find, focus, move, resize, minimize, geometry, tile)
- **Client**: Corresponding `RecorderClient` methods for all Director operations
- **CLI**: New commands (`mouse-move`, `mouse-click`, `keyboard-type`, `keyboard-press`, `window-find`, etc.) for scripting Director actions from the command line
- **Tests**: 36 new tests covering all Director server endpoints (validation, success, error cases)
- **Docs**: Full API reference added to `docs/server.md`

All endpoints work for both default (`/director/...`) and named sessions (`/sessions/{name}/director/...`).

## Test plan
- [x] All 499 tests pass (`uv run python3 -m pytest tests/ -v --ignore=tests/e2e --ignore=tests/e2e-apps`)
- [ ] CI passes
- [ ] SDK updates (Go, Node, Ruby, Java) in follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)