### PR TITLE
simplify: collapse all extras into base package

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,7 @@ If it has a window and can run on X11, thea can record it.
 ## Install
 
 ```bash
-# Client only (zero dependencies — for test suites and automation scripts)
 pip install thea-recorder
-
-# Server + CLI (includes Flask and Click)
-pip install thea-recorder[server]
 ```
 
 System dependencies (for the server, in your Docker image or CI runner):
@@ -183,7 +179,7 @@ RUN apt-get update && apt-get install -qyy --no-install-recommends \
     chromium-driver xvfb ffmpeg x11-xserver-utils fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install thea-recorder[server]
+RUN pip install thea-recorder
 EXPOSE 9123
 CMD ["thea", "serve", "--host", "0.0.0.0", "--port", "9123"]
 ```

--- a/docs/how-recording-works.md
+++ b/docs/how-recording-works.md
@@ -361,7 +361,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Thea
-RUN pip install thea-recorder[server]
+RUN pip install thea-recorder
 
 # Everything runs in this one container:
 # Thea + Xvfb + ffmpeg + your application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "thea-recorder"
 version = "0.8.0"
 description = "Record Xvfb virtual displays as MP4 video with live panel overlays and interactive HTML reports."
 requires-python = ">=3.10"
-dependencies = ["click>=8.0"]
+dependencies = ["click>=8.0", "flask>=3.0", "selenium>=4.0"]
 license = {text = "MIT"}
 readme = "README.md"
 keywords = ["testing", "video", "recording", "xvfb", "ffmpeg", "e2e", "behave", "cucumber", "selenium"]
@@ -23,9 +23,7 @@ classifiers = [
 thea = "thea.cli:main"
 
 [project.optional-dependencies]
-server = ["flask>=3.0"]
-selenium = ["selenium>=4.0"]
-dev = ["pytest", "flask>=3.0"]
+dev = ["pytest"]
 
 [project.urls]
 Homepage = "https://github.com/BarkingIguana/thea"

--- a/site/index.html
+++ b/site/index.html
@@ -1432,9 +1432,9 @@ curl <span class="op">-o</span> login_test.mp4 http://localhost:9123/recordings/
             </div>
             <div class="feature-card">
                 <div class="feature-icon">&#128230;</div>
-                <h4>Zero dependencies</h4>
+                <h4>Minimal dependencies</h4>
                 <p>
-                    Pure Python stdlib. No pip install chain. No version conflicts.
+                    No pip install chain headaches.
                     Just add it to your Docker image and go.
                 </p>
             </div>
@@ -1460,6 +1460,14 @@ curl <span class="op">-o</span> login_test.mp4 http://localhost:9123/recordings/
                 <p>
                     Tile multiple recordings side-by-side, stacked, or in a grid. Add
                     timed highlight borders to call attention to specific moments.
+                </p>
+            </div>
+            <div class="feature-card">
+                <div class="feature-icon">&#127918;</div>
+                <h4>Human-like interaction</h4>
+                <p>
+                    Built-in Director for realistic mouse movement, natural typing rhythm,
+                    and window management. Smooth trajectories, not instant teleportation.
                 </p>
             </div>
         </div>

--- a/src/thea/__init__.py
+++ b/src/thea/__init__.py
@@ -1,28 +1,25 @@
-# Client (stdlib-only, always available)
+# Client
 from .client import CompositionHelper, RecorderClient, RecorderError, RecordingResult
 
-# Layout (stdlib-only, always available)
+# Layout
 from .layout import Region, validate_regions, generate_testcard
 
-# Director (always available — uses xdotool at runtime)
+# Director
 from .director import Director, MotionConfig, RhythmConfig
 
-# Server components (require flask/click — installed via `pip install thea-recorder[server]`)
-try:
-    from .recorder import Recorder, PANEL_HEIGHT, LINE_HEIGHT
-    from .report import generate_report
-    from .composer import CompositionSpec, Highlight, render_composition
-except ImportError:
-    pass
+# Recorder & server components
+from .recorder import Recorder, PANEL_HEIGHT, LINE_HEIGHT
+from .report import generate_report
+from .composer import CompositionSpec, Highlight, render_composition
 
 __all__ = [
     # Client
     "RecorderClient", "RecorderError", "RecordingResult", "CompositionHelper",
     # Layout
     "Region", "validate_regions", "generate_testcard",
-    # Director (always available)
+    # Director
     "Director", "MotionConfig", "RhythmConfig",
-    # Server (available when [server] extra is installed)
+    # Recorder & server
     "Recorder", "PANEL_HEIGHT", "LINE_HEIGHT",
     "generate_report",
     "CompositionSpec", "Highlight", "render_composition",

--- a/src/thea/director/bridges/selenium.py
+++ b/src/thea/director/bridges/selenium.py
@@ -19,7 +19,7 @@ Usage::
     human.find_element(By.ID, "email").type("user@example.com")
     human.find_element(By.ID, "submit").click()
 
-Requires the ``selenium`` package: ``pip install thea-recorder[selenium]``
+Requires ``pip install thea-recorder`` (selenium is included).
 """
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -352,33 +352,27 @@ wheels = [
 
 [[package]]
 name = "thea-recorder"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "flask" },
+    { name = "selenium" },
 ]
 
 [package.optional-dependencies]
 dev = [
-    { name = "flask" },
     { name = "pytest" },
-]
-selenium = [
-    { name = "selenium" },
-]
-server = [
-    { name = "flask" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
-    { name = "flask", marker = "extra == 'dev'", specifier = ">=3.0" },
-    { name = "flask", marker = "extra == 'server'", specifier = ">=3.0" },
+    { name = "flask", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'dev'" },
-    { name = "selenium", marker = "extra == 'selenium'", specifier = ">=4.0" },
+    { name = "selenium", specifier = ">=4.0" },
 ]
-provides-extras = ["server", "selenium", "dev"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
## Summary
- `pip install thea-recorder` now includes everything: Flask, Click, Selenium
- Removed `[server]` and `[selenium]` extras — only `[dev]` remains for pytest
- Updated all docs, README, CLAUDE.md, marketing site, and bridge docstrings
- Added Director feature card to marketing site
- Cleaned up `__init__.py` — no more try/except ImportError guard

## Test plan
- [x] All 499 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)