### PR TITLE
fix: correct GitHub repo URLs across project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ thea = "thea.cli:main"
 dev = ["pytest"]
 
 [project.urls]
-Homepage = "https://github.com/BarkingIguana/thea"
+Homepage = "https://github.com/BarkingIguana/thea-recorder"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/site/index.html
+++ b/site/index.html
@@ -1219,7 +1219,7 @@ footer {
         <li><a href="#parallel">Parallel</a></li>
         <li><a href="#layout">Layout</a></li>
         <li><a href="docs/">Docs</a></li>
-        <li><a href="https://github.com/BarkingIguana/thea" class="nav-pip">pip install thea-recorder</a></li>
+        <li><a href="https://github.com/BarkingIguana/thea-recorder" class="nav-pip">pip install thea-recorder</a></li>
     </ul>
 </nav>
 
@@ -1237,7 +1237,7 @@ footer {
                 to that exact moment.
             </p>
             <div class="hero-actions">
-                <a href="https://github.com/BarkingIguana/thea" class="btn-primary">
+                <a href="https://github.com/BarkingIguana/thea-recorder" class="btn-primary">
                     View on GitHub
                 </a>
                 <a href="#examples" class="btn-ghost">See examples</a>
@@ -2411,10 +2411,10 @@ curl http://localhost:9123/testcard <span class="op">-o</span> layout.svg</div>
         </div>
         <p class="footer-tagline">Record your virtual display. Watch it back.</p>
         <div class="footer-links">
-            <a href="https://github.com/BarkingIguana/thea">GitHub</a>
-            <a href="https://github.com/BarkingIguana/thea#install">Install</a>
-            <a href="https://github.com/BarkingIguana/thea#api">API Docs</a>
-            <a href="https://github.com/BarkingIguana/thea/blob/main/LICENSE">MIT License</a>
+            <a href="https://github.com/BarkingIguana/thea-recorder">GitHub</a>
+            <a href="https://github.com/BarkingIguana/thea-recorder#install">Install</a>
+            <a href="https://github.com/BarkingIguana/thea-recorder#api">API Docs</a>
+            <a href="https://github.com/BarkingIguana/thea-recorder/blob/main/LICENSE">MIT License</a>
         </div>
         <p class="footer-copy">Built by Mechanical Rock. Open source under the MIT License.</p>
     </div>


### PR DESCRIPTION
## Summary
- Fixed Homepage URL in `pyproject.toml`: `/thea` → `/thea-recorder` (fixes #12)
- Fixed 5 GitHub links in `site/index.html` (fixes #13)

## Test plan
- [x] All 499 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)