### PR TITLE
fix: use default openbox config instead of /dev/null

### DIFF
--- a/src/thea/director/director.py
+++ b/src/thea/director/director.py
@@ -71,7 +71,7 @@ class Director:
             return  # WM already running
 
         self._wm_proc = subprocess.Popen(
-            ["openbox", "--config-file", "/dev/null"],
+            ["openbox"],
             env=self._env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/tests/e2e-apps/conftest.py
+++ b/tests/e2e-apps/conftest.py
@@ -38,7 +38,7 @@ def recorder(output_dir):
     # Start a lightweight window manager so that window focus,
     # activation, and resizing work properly with xdotool.
     rec.launch_app(
-        ["openbox", "--config-file", "/dev/null"],
+        ["openbox"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )


### PR DESCRIPTION
## Summary
- Removed `--config-file /dev/null` from openbox launch in Director and e2e conftest
- The `/dev/null` config caused an XML parse error dialog to appear on screen during recording
- Default openbox config (`/etc/xdg/openbox/rc.xml`) is already minimal and suitable

Fixes #16

## Test plan
- [x] All director tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)