### PR TITLE
Add recording annotation endpoints

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,17 @@ thea elapsed
 thea stop-recording
 ```
 
+### Annotations
+
+```bash
+# Add an annotation to the active recording
+thea annotate --label "login_started"
+thea annotate --label "step_1" --time 5.5 --details "Clicked submit button"
+
+# List annotations for the active recording
+thea list-annotations
+```
+
 ### File Operations
 
 ```bash

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -87,6 +87,8 @@ Every SDK provides:
 | `stop_recording()` | Stop recording, get path + elapsed |
 | `recording_elapsed()` | Get elapsed seconds |
 | `recording_status()` | Get recording state |
+| `add_annotation(label, time, details)` | Add a timestamped annotation to the active recording |
+| `list_annotations()` | List annotations for the active recording |
 | `list_recordings()` | List available MP4 files |
 | `download_recording(name, path)` | Download MP4 to local file |
 | `recording_info(name)` | Get file metadata |

--- a/docs/server.md
+++ b/docs/server.md
@@ -203,6 +203,45 @@ curl http://localhost:9123/recording/status
 {"recording": true, "name": "login_test", "elapsed": 12.5}
 ```
 
+### Annotations
+
+Annotations are timestamped markers attached to the active recording. They are returned in the stop-recording response and emitted as events.
+
+#### Add annotation
+```bash
+curl -X POST http://localhost:9123/recording/annotations \
+  -H "Content-Type: application/json" \
+  -d '{"label": "login_started", "details": "User clicked login button"}'
+```
+**Response** `201`:
+```json
+{"label": "login_started", "time": 3.456, "details": "User clicked login button"}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `label` | yes | Short annotation label |
+| `time` | no | Time offset in seconds (default: current elapsed) |
+| `details` | no | Optional longer description |
+
+**Error** `400` if label is missing or time is negative. `409` if not recording.
+
+#### List annotations
+```bash
+curl http://localhost:9123/recording/annotations
+```
+**Response** `200`:
+```json
+[
+  {"label": "login_started", "time": 3.456},
+  {"label": "assertion_passed", "time": 8.2, "details": "Login form submitted"}
+]
+```
+
+**Error** `409` if not recording.
+
+Annotations are included in the stop-recording response under the `annotations` key and cleared when the recording stops.
+
 ### File Access
 
 #### List recordings

--- a/site/index.html
+++ b/site/index.html
@@ -1497,6 +1497,15 @@ curl <span class="op">-o</span> login_test.mp4 http://localhost:9123/recordings/
                     videos at any time offset. Perfect for CI thumbnails and test reports.
                 </p>
             </div>
+            <div class="feature-card">
+                <div class="feature-icon">&#128205;</div>
+                <h4>Recording annotations</h4>
+                <p>
+                    Mark key moments during a recording with timestamped labels.
+                    Annotations are returned when the recording stops and appear in the
+                    event log for richer reports and debugging.
+                </p>
+            </div>
         </div>
     </div>
 </section>

--- a/src/thea/cli.py
+++ b/src/thea/cli.py
@@ -345,6 +345,44 @@ def elapsed(ctx):
     _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
 
 
+@main.command("annotate")
+@click.option("--label", required=True, help="Annotation label.")
+@click.option("--time", "time_offset", type=float, default=None, help="Time offset in seconds (default: current elapsed).")
+@click.option("--details", default=None, help="Optional details text.")
+@click.pass_context
+def annotate(ctx, label, time_offset, details):
+    """Add an annotation to the active recording."""
+    server = _server_url(ctx)
+    body = {"label": label}
+    if time_offset is not None:
+        body["time"] = time_offset
+    if details is not None:
+        body["details"] = details
+    try:
+        status, data = _request(f"{server}/recording/annotations", method="POST", data=body)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("list-annotations")
+@click.pass_context
+def list_annotations(ctx):
+    """List annotations for the active recording."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(f"{server}/recording/annotations")
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
 # ── File commands ────────────────────────────────────────────────────────
 
 @main.command("list-recordings")

--- a/src/thea/client.py
+++ b/src/thea/client.py
@@ -335,6 +335,51 @@ class RecorderClient:
         """GET /recording/status — full recording status."""
         return self._request("GET", "/recording/status")
 
+    def add_annotation(
+        self,
+        label: str,
+        *,
+        time: float | None = None,
+        details: str | None = None,
+    ) -> dict[str, Any]:
+        """POST /recording/annotations — add an annotation to the active recording.
+
+        Parameters
+        ----------
+        label:
+            Short label for the annotation (e.g. ``"login_started"``).
+        time:
+            Time offset in seconds into the recording.  *None* uses the
+            current recording elapsed time.
+        details:
+            Optional longer description.
+
+        Returns
+        -------
+        dict
+            The created annotation with ``label``, ``time``, and
+            optional ``details``.
+        """
+        body: dict[str, Any] = {"label": label}
+        if time is not None:
+            body["time"] = time
+        if details is not None:
+            body["details"] = details
+        return self._request("POST", "/recording/annotations", body)
+
+    def list_annotations(self) -> list[dict[str, Any]]:
+        """GET /recording/annotations — list annotations for the active recording.
+
+        Returns
+        -------
+        list
+            List of annotation dicts.
+        """
+        result = self._request("GET", "/recording/annotations")
+        if isinstance(result, list):
+            return result  # type: ignore[return-value]
+        return []
+
     # ------------------------------------------------------------------
     # Recordings archive
     # ------------------------------------------------------------------

--- a/src/thea/server.py
+++ b/src/thea/server.py
@@ -170,6 +170,7 @@ def create_app(
             "display": display_num,
             "events": [],
             "events_lock": threading.Lock(),
+            "annotations": [],
         }
 
     def _emit_event(sess: dict, event: str, details: dict | None = None) -> dict:
@@ -495,9 +496,16 @@ img.onerror = function() {{
             path = rec.stop_recording()
             name = cur_name["name"]
             cur_name["name"] = None
+        annotations = []
         if sess:
+            with sess["events_lock"]:
+                annotations = list(sess["annotations"])
+                sess["annotations"] = []
             _emit_event(sess, "recording.stopped", {"name": name, "elapsed": round(elapsed, 2), "path": path})
-        return jsonify({"path": path, "elapsed": round(elapsed, 2), "name": name}), 200
+        result = {"path": path, "elapsed": round(elapsed, 2), "name": name}
+        if annotations:
+            result["annotations"] = annotations
+        return jsonify(result), 200
 
     def _impl_recording_elapsed(rec, sess_lock):
         with sess_lock:
@@ -510,6 +518,40 @@ img.onerror = function() {{
             name = cur_name["name"] if is_recording else None
             elapsed = round(rec.recording_elapsed, 2)
         return jsonify({"recording": is_recording, "name": name, "elapsed": elapsed}), 200
+
+    def _impl_annotations_add(rec, sess_lock, sess):
+        data = request.get_json(silent=True) or {}
+        label = data.get("label")
+        if not label or not isinstance(label, str) or label.strip() == "":
+            return jsonify({"error": "field 'label' is required and must be a non-empty string"}), 400
+        with sess_lock:
+            if rec._ffmpeg_proc is None:
+                return jsonify({"error": "not recording"}), 409
+            elapsed = rec.recording_elapsed
+        time_offset = data.get("time")
+        if time_offset is not None:
+            if not isinstance(time_offset, (int, float)) or time_offset < 0:
+                return jsonify({"error": "'time' must be a non-negative number"}), 400
+        else:
+            time_offset = round(elapsed, 3)
+        annotation = {
+            "label": label.strip(),
+            "time": round(time_offset, 3),
+        }
+        details = data.get("details")
+        if details is not None:
+            annotation["details"] = details
+        with sess["events_lock"]:
+            sess["annotations"].append(annotation)
+        _emit_event(sess, "recording.annotated", {"label": annotation["label"], "time": annotation["time"]})
+        return jsonify(annotation), 201
+
+    def _impl_annotations_list(rec, sess_lock, sess):
+        with sess_lock:
+            if rec._ffmpeg_proc is None:
+                return jsonify({"error": "not recording"}), 409
+        with sess["events_lock"]:
+            return jsonify(list(sess["annotations"])), 200
 
     def _impl_cleanup(rec, sess_lock, cur_name, sess=None):
         with sess_lock:
@@ -762,6 +804,20 @@ img.onerror = function() {{
             return err
         return _impl_recording_status(sess["recorder"], sess["lock"], sess["current_name"])
 
+    @app.route("/sessions/<session_name>/recording/annotations", methods=["POST"])
+    def sess_annotations_add(session_name):
+        sess, err = _session_or_404(session_name)
+        if err:
+            return err
+        return _impl_annotations_add(sess["recorder"], sess["lock"], sess)
+
+    @app.route("/sessions/<session_name>/recording/annotations", methods=["GET"])
+    def sess_annotations_list(session_name):
+        sess, err = _session_or_404(session_name)
+        if err:
+            return err
+        return _impl_annotations_list(sess["recorder"], sess["lock"], sess)
+
     @app.route("/sessions/<session_name>/cleanup", methods=["POST"])
     def sess_cleanup(session_name):
         sess, err = _session_or_404(session_name)
@@ -843,6 +899,14 @@ img.onerror = function() {{
     @app.route("/recording/status", methods=["GET"])
     def recording_status():
         return _impl_recording_status(recorder, lock, current_recording_name)
+
+    @app.route("/recording/annotations", methods=["POST"])
+    def annotations_add():
+        return _impl_annotations_add(recorder, lock, _default)
+
+    @app.route("/recording/annotations", methods=["GET"])
+    def annotations_list():
+        return _impl_annotations_list(recorder, lock, _default)
 
     # -- File access endpoints (shared across all sessions) ----------------
 

--- a/tests/test_server_annotations.py
+++ b/tests/test_server_annotations.py
@@ -1,0 +1,212 @@
+"""Tests for the recording annotation endpoints."""
+
+from unittest.mock import patch, Mock
+
+import pytest
+
+from thea.server import create_app
+
+
+@pytest.fixture
+def app(tmp_path):
+    with patch("thea.recorder.subprocess.Popen"), \
+         patch("thea.recorder.subprocess.run"), \
+         patch("thea.recorder.os.path.exists", return_value=True):
+        app = create_app(output_dir=str(tmp_path), display=42)
+        app.config["TESTING"] = True
+        yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _start_recording(client, name="demo"):
+    with patch("thea.recorder.subprocess.Popen") as mock_popen:
+        mock_proc = Mock()
+        mock_proc.poll.return_value = None
+        mock_proc.returncode = 0
+        mock_proc.stderr.read.return_value = b""
+        mock_popen.return_value = mock_proc
+        client.post("/display/start")
+        resp = client.post("/recording/start", json={"name": name})
+        assert resp.status_code == 201
+
+
+class TestAnnotationsEndpoint:
+    def test_add_annotation(self, client):
+        _start_recording(client)
+        resp = client.post("/recording/annotations", json={
+            "label": "login_started",
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["label"] == "login_started"
+        assert "time" in data
+        assert data["time"] >= 0
+
+    def test_add_annotation_with_time(self, client):
+        _start_recording(client)
+        resp = client.post("/recording/annotations", json={
+            "label": "step_1",
+            "time": 5.5,
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["label"] == "step_1"
+        assert data["time"] == 5.5
+
+    def test_add_annotation_with_details(self, client):
+        _start_recording(client)
+        resp = client.post("/recording/annotations", json={
+            "label": "assertion_failed",
+            "details": "Expected 200 got 404",
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["details"] == "Expected 200 got 404"
+
+    def test_add_annotation_requires_label(self, client):
+        _start_recording(client)
+        resp = client.post("/recording/annotations", json={})
+        assert resp.status_code == 400
+        assert "label" in resp.get_json()["error"]
+
+    def test_add_annotation_empty_label(self, client):
+        _start_recording(client)
+        resp = client.post("/recording/annotations", json={"label": "  "})
+        assert resp.status_code == 400
+
+    def test_add_annotation_invalid_time(self, client):
+        _start_recording(client)
+        resp = client.post("/recording/annotations", json={
+            "label": "test",
+            "time": -1,
+        })
+        assert resp.status_code == 400
+
+    def test_add_annotation_not_recording(self, client):
+        resp = client.post("/recording/annotations", json={
+            "label": "test",
+        })
+        assert resp.status_code == 409
+
+    def test_list_annotations(self, client):
+        _start_recording(client)
+        client.post("/recording/annotations", json={"label": "a"})
+        client.post("/recording/annotations", json={"label": "b", "time": 3.0})
+
+        resp = client.get("/recording/annotations")
+        assert resp.status_code == 200
+        annotations = resp.get_json()
+        assert len(annotations) == 2
+        assert annotations[0]["label"] == "a"
+        assert annotations[1]["label"] == "b"
+        assert annotations[1]["time"] == 3.0
+
+    def test_list_annotations_not_recording(self, client):
+        resp = client.get("/recording/annotations")
+        assert resp.status_code == 409
+
+    def test_annotations_in_stop_result(self, client):
+        _start_recording(client)
+        client.post("/recording/annotations", json={"label": "step_1", "time": 1.0})
+        client.post("/recording/annotations", json={"label": "step_2", "time": 2.0})
+
+        with patch("thea.recorder.Recorder.stop_recording", return_value="/tmp/demo.mp4"), \
+             patch("thea.recorder.Recorder.recording_elapsed", new_callable=lambda: property(lambda self: 5.0)):
+            resp = client.post("/recording/stop")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "annotations" in data
+        assert len(data["annotations"]) == 2
+        assert data["annotations"][0]["label"] == "step_1"
+
+    def test_annotations_cleared_after_stop(self, client):
+        _start_recording(client)
+        client.post("/recording/annotations", json={"label": "first_run"})
+
+        # Stop the recording
+        resp = client.post("/recording/stop")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data.get("annotations", [])) == 1
+
+        # Start a new recording — annotations should be empty
+        _start_recording(client, name="second")
+        resp = client.get("/recording/annotations")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+
+    def test_annotation_emits_event(self, client):
+        _start_recording(client)
+        client.post("/recording/annotations", json={"label": "marker"})
+
+        resp = client.get("/events")
+        events = resp.get_json()
+        annotated = [e for e in events if e["event"] == "recording.annotated"]
+        assert len(annotated) == 1
+        assert annotated[0]["details"]["label"] == "marker"
+
+    def test_annotations_without_recording_omitted_from_stop(self, client):
+        """Stop result should not include 'annotations' key when there are none."""
+        _start_recording(client)
+
+        with patch("thea.recorder.Recorder.stop_recording", return_value="/tmp/demo.mp4"), \
+             patch("thea.recorder.Recorder.recording_elapsed", new_callable=lambda: property(lambda self: 5.0)):
+            resp = client.post("/recording/stop")
+
+        data = resp.get_json()
+        assert "annotations" not in data
+
+
+class TestSessionAnnotations:
+    def _create_session(self, client, name):
+        with patch("thea.recorder.subprocess.Popen"), \
+             patch("thea.recorder.subprocess.run"), \
+             patch("thea.recorder.os.path.exists", return_value=True):
+            return client.post("/sessions", json={"name": name})
+
+    def _start_session_recording(self, client, session_name, rec_name="demo"):
+        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+            mock_proc = Mock()
+            mock_proc.poll.return_value = None
+            mock_popen.return_value = mock_proc
+            client.post(f"/sessions/{session_name}/display/start")
+            resp = client.post(f"/sessions/{session_name}/recording/start", json={"name": rec_name})
+            assert resp.status_code == 201
+
+    def test_session_annotations(self, client):
+        self._create_session(client, "alice")
+        self._start_session_recording(client, "alice")
+
+        resp = client.post("/sessions/alice/recording/annotations", json={
+            "label": "login",
+        })
+        assert resp.status_code == 201
+
+        resp = client.get("/sessions/alice/recording/annotations")
+        assert resp.status_code == 200
+        assert len(resp.get_json()) == 1
+
+    def test_session_annotations_isolated(self, client):
+        self._create_session(client, "alice")
+        self._create_session(client, "bob")
+        self._start_session_recording(client, "alice")
+        self._start_session_recording(client, "bob")
+
+        client.post("/sessions/alice/recording/annotations", json={"label": "alice_marker"})
+        client.post("/sessions/bob/recording/annotations", json={"label": "bob_marker"})
+
+        alice_resp = client.get("/sessions/alice/recording/annotations")
+        bob_resp = client.get("/sessions/bob/recording/annotations")
+
+        alice_annotations = alice_resp.get_json()
+        bob_annotations = bob_resp.get_json()
+
+        assert len(alice_annotations) == 1
+        assert alice_annotations[0]["label"] == "alice_marker"
+        assert len(bob_annotations) == 1
+        assert bob_annotations[0]["label"] == "bob_marker"


### PR DESCRIPTION
## Summary

- Add `POST /recording/annotations` and `GET /recording/annotations` endpoints for timestamped markers during recordings
- Annotations are included in the stop-recording response (`annotations` key) and cleared between recordings
- Emit `recording.annotated` events to the event log
- Both default and session-scoped routes supported
- Python client: `add_annotation()` and `list_annotations()` methods
- CLI: `thea annotate --label ... [--time ...] [--details ...]` and `thea list-annotations`
- 15 new tests (561 total, all passing)
- Updated: server.md, cli.md, sdks.md, site/index.html

Closes #21

## Test plan

- [x] All 561 Python tests pass
- [x] Annotation CRUD: add, list, clear on stop
- [x] Validation: missing label, empty label, negative time, not-recording
- [x] Annotations in stop result (present when populated, omitted when empty)
- [x] Event emission (`recording.annotated`)
- [x] Session isolation (annotations don't leak between sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)