### PR TITLE
Bring all 5 SDKs to feature parity

### DIFF
--- a/sdks/go/thea/recorder.go
+++ b/sdks/go/thea/recorder.go
@@ -102,6 +102,102 @@ type CompositionHighlight struct {
 	Duration  float64 `json:"duration"`
 }
 
+// Annotation describes a timestamped annotation on a recording.
+type Annotation struct {
+	Label   string  `json:"label"`
+	Time    float64 `json:"time"`
+	Details string  `json:"details,omitempty"`
+}
+
+// AddAnnotationRequest is the payload for POST /recording/annotations.
+type AddAnnotationRequest struct {
+	Label   string   `json:"label"`
+	Time    *float64 `json:"time,omitempty"`
+	Details string   `json:"details,omitempty"`
+}
+
+// Event describes an entry in the session event log.
+type Event struct {
+	Event   string         `json:"event"`
+	Time    string         `json:"time"`
+	Elapsed float64        `json:"elapsed"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// MousePos describes the current cursor position.
+type MousePos struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+// MouseMoveRequest is the payload for POST /director/mouse/move.
+type MouseMoveRequest struct {
+	X           int      `json:"x"`
+	Y           int      `json:"y"`
+	Duration    *float64 `json:"duration,omitempty"`
+	TargetWidth *float64 `json:"target_width,omitempty"`
+}
+
+// MouseClickRequest is the payload for POST /director/mouse/click.
+type MouseClickRequest struct {
+	X        *int     `json:"x,omitempty"`
+	Y        *int     `json:"y,omitempty"`
+	Button   int      `json:"button"`
+	Duration *float64 `json:"duration,omitempty"`
+}
+
+// MouseDragRequest is the payload for POST /director/mouse/drag.
+type MouseDragRequest struct {
+	StartX   int      `json:"start_x"`
+	StartY   int      `json:"start_y"`
+	EndX     int      `json:"end_x"`
+	EndY     int      `json:"end_y"`
+	Button   int      `json:"button"`
+	Duration *float64 `json:"duration,omitempty"`
+}
+
+// MouseScrollRequest is the payload for POST /director/mouse/scroll.
+type MouseScrollRequest struct {
+	Clicks int  `json:"clicks"`
+	X      *int `json:"x,omitempty"`
+	Y      *int `json:"y,omitempty"`
+}
+
+// KeyboardTypeRequest is the payload for POST /director/keyboard/type.
+type KeyboardTypeRequest struct {
+	Text string   `json:"text"`
+	WPM  *float64 `json:"wpm,omitempty"`
+}
+
+// WindowFindRequest is the payload for POST /director/window/find.
+type WindowFindRequest struct {
+	Name      string  `json:"name,omitempty"`
+	ClassName string  `json:"class,omitempty"`
+	Timeout   float64 `json:"timeout"`
+}
+
+// WindowInfo is the payload returned by POST /director/window/find.
+type WindowInfo struct {
+	WindowID string `json:"window_id"`
+	Name     string `json:"name,omitempty"`
+	Class    string `json:"class,omitempty"`
+}
+
+// WindowGeometryInfo is the payload returned by GET /director/window/{id}/geometry.
+type WindowGeometryInfo struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+// WindowTileRequest is the payload for POST /director/window/tile.
+type WindowTileRequest struct {
+	WindowIDs []string `json:"window_ids"`
+	Layout    string   `json:"layout"`
+	Bounds    []int    `json:"bounds,omitempty"`
+}
+
 // CompositionRequest is the payload for POST /compositions.
 type CompositionRequest struct {
 	Name           string                 `json:"name"`
@@ -181,6 +277,24 @@ func (c *Client) StartDisplay(ctx context.Context, displaySize ...string) error 
 // StopDisplay stops the virtual display (POST /display/stop).
 func (c *Client) StopDisplay(ctx context.Context) error {
 	return c.doSimple(ctx, http.MethodPost, "/display/stop", nil, http.StatusOK)
+}
+
+// DisplayScreenshot captures a JPEG screenshot of the live display
+// (GET /display/screenshot?quality=N). Returns the raw JPEG bytes.
+func (c *Client) DisplayScreenshot(ctx context.Context, quality int) ([]byte, error) {
+	return c.doRawGet(ctx, fmt.Sprintf("/display/screenshot?quality=%d", quality))
+}
+
+// DisplayStreamURL returns the URL for the live MJPEG stream. No HTTP call
+// is made.
+func (c *Client) DisplayStreamURL(fps int) string {
+	return fmt.Sprintf("%s/display/stream?fps=%d", c.baseURL, fps)
+}
+
+// DisplayViewerURL returns the URL for the HTML live viewer page. No HTTP
+// call is made.
+func (c *Client) DisplayViewerURL() string {
+	return c.baseURL + "/display/view"
 }
 
 // ---------------------------------------------------------------------------
@@ -276,6 +390,26 @@ func (c *Client) RecordingStatusInfo(ctx context.Context) (*RecordingStatus, err
 	return &status, nil
 }
 
+// AddAnnotation adds an annotation to the active recording
+// (POST /recording/annotations).
+func (c *Client) AddAnnotation(ctx context.Context, req AddAnnotationRequest) (*Annotation, error) {
+	var ann Annotation
+	if err := c.doJSON(ctx, http.MethodPost, "/recording/annotations", req, http.StatusCreated, &ann); err != nil {
+		return nil, err
+	}
+	return &ann, nil
+}
+
+// ListAnnotations returns all annotations for the active recording
+// (GET /recording/annotations).
+func (c *Client) ListAnnotations(ctx context.Context) ([]Annotation, error) {
+	var anns []Annotation
+	if err := c.doJSON(ctx, http.MethodGet, "/recording/annotations", nil, http.StatusOK, &anns); err != nil {
+		return nil, err
+	}
+	return anns, nil
+}
+
 // ListRecordings returns all stored recordings (GET /recordings).
 func (c *Client) ListRecordings(ctx context.Context) ([]RecordingInfo, error) {
 	var list []RecordingInfo
@@ -293,6 +427,13 @@ func (c *Client) GetRecordingInfo(ctx context.Context, name string) (*RecordingI
 		return nil, err
 	}
 	return &info, nil
+}
+
+// RecordingScreenshot extracts a JPEG frame from a saved recording
+// (GET /recordings/{name}/screenshot?t=N&quality=N). Returns the raw JPEG bytes.
+func (c *Client) RecordingScreenshot(ctx context.Context, name string, timeOffset float64, quality int) ([]byte, error) {
+	path := fmt.Sprintf("/recordings/%s/screenshot?t=%.3f&quality=%d", name, timeOffset, quality)
+	return c.doRawGet(ctx, path)
 }
 
 // DownloadRecording streams the MP4 for the named recording into w
@@ -363,15 +504,16 @@ func (c *Client) EnsureRecording(ctx context.Context, name string) (*RecordingSt
 }
 
 // CreateCompositionAndWait creates a composition and polls until it completes,
-// fails, or the timeout elapses. If the composition already exists (409), it
-// falls through to polling the existing one.
+// fails, or the timeout elapses. If the composition already exists (409) or
+// was accepted for async processing (202), it falls through to polling.
 func (c *Client) CreateCompositionAndWait(ctx context.Context, req CompositionRequest, timeout time.Duration) (*CompositionStatus, error) {
 	_, err := c.CreateComposition(ctx, req)
 	if err != nil {
-		if !IsConflict(err) {
+		if !IsConflict(err) && !IsAccepted(err) {
 			return nil, err
 		}
-		// Composition already exists — poll it.
+		// 409 Conflict: composition already exists — poll it.
+		// 202 Accepted: composition created asynchronously — poll it.
 	}
 	return c.WaitForComposition(ctx, req.Name, timeout)
 }
@@ -499,6 +641,41 @@ func (c *Client) WaitForComposition(ctx context.Context, name string, timeout ti
 }
 
 // ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+// Events returns the event log for the current session (GET /events).
+// An optional since value filters to events with elapsed greater than that value.
+func (c *Client) Events(ctx context.Context, since ...float64) ([]Event, error) {
+	urlPath := "/events"
+	if len(since) > 0 {
+		urlPath = fmt.Sprintf("/events?since=%g", since[0])
+	}
+	var events []Event
+	// Events endpoint may have query params, use doRawGet + decode.
+	if len(since) > 0 {
+		data, err := c.doRawGet(ctx, urlPath)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(data, &events); err != nil {
+			return nil, err
+		}
+		return events, nil
+	}
+	if err := c.doJSON(ctx, http.MethodGet, urlPath, nil, http.StatusOK, &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// DashboardURL returns the URL for the HTML dashboard page. No HTTP call
+// is made.
+func (c *Client) DashboardURL() string {
+	return c.baseURL + "/dashboard"
+}
+
+// ---------------------------------------------------------------------------
 // Layout validation / Testcard
 // ---------------------------------------------------------------------------
 
@@ -581,8 +758,176 @@ func (c *Client) WaitUntilReady(ctx context.Context, timeout time.Duration) erro
 }
 
 // ---------------------------------------------------------------------------
+// Director — Mouse
+// ---------------------------------------------------------------------------
+
+// MouseMove moves the mouse cursor (POST /director/mouse/move).
+func (c *Client) MouseMove(ctx context.Context, req MouseMoveRequest) error {
+	return c.doSimple(ctx, http.MethodPost, "/director/mouse/move", req, http.StatusOK)
+}
+
+// MouseClick clicks the mouse (POST /director/mouse/click).
+func (c *Client) MouseClick(ctx context.Context, req MouseClickRequest) error {
+	if req.Button == 0 {
+		req.Button = 1
+	}
+	return c.doSimple(ctx, http.MethodPost, "/director/mouse/click", req, http.StatusOK)
+}
+
+// MouseDoubleClick double-clicks the mouse (POST /director/mouse/double-click).
+func (c *Client) MouseDoubleClick(ctx context.Context, x, y *int) error {
+	body := map[string]any{}
+	if x != nil {
+		body["x"] = *x
+	}
+	if y != nil {
+		body["y"] = *y
+	}
+	return c.doSimple(ctx, http.MethodPost, "/director/mouse/double-click", body, http.StatusOK)
+}
+
+// MouseRightClick right-clicks the mouse (POST /director/mouse/right-click).
+func (c *Client) MouseRightClick(ctx context.Context, x, y *int) error {
+	body := map[string]any{}
+	if x != nil {
+		body["x"] = *x
+	}
+	if y != nil {
+		body["y"] = *y
+	}
+	return c.doSimple(ctx, http.MethodPost, "/director/mouse/right-click", body, http.StatusOK)
+}
+
+// MouseDrag drags from one point to another (POST /director/mouse/drag).
+func (c *Client) MouseDrag(ctx context.Context, req MouseDragRequest) error {
+	if req.Button == 0 {
+		req.Button = 1
+	}
+	return c.doSimple(ctx, http.MethodPost, "/director/mouse/drag", req, http.StatusOK)
+}
+
+// MouseScroll scrolls the mouse wheel (POST /director/mouse/scroll).
+func (c *Client) MouseScroll(ctx context.Context, req MouseScrollRequest) error {
+	return c.doSimple(ctx, http.MethodPost, "/director/mouse/scroll", req, http.StatusOK)
+}
+
+// MousePosition returns the current cursor position
+// (GET /director/mouse/position).
+func (c *Client) MousePosition(ctx context.Context) (*MousePos, error) {
+	var pos MousePos
+	if err := c.doJSON(ctx, http.MethodGet, "/director/mouse/position", nil, http.StatusOK, &pos); err != nil {
+		return nil, err
+	}
+	return &pos, nil
+}
+
+// ---------------------------------------------------------------------------
+// Director — Keyboard
+// ---------------------------------------------------------------------------
+
+// KeyboardType types text with human-like rhythm
+// (POST /director/keyboard/type).
+func (c *Client) KeyboardType(ctx context.Context, req KeyboardTypeRequest) error {
+	return c.doSimple(ctx, http.MethodPost, "/director/keyboard/type", req, http.StatusOK)
+}
+
+// KeyboardPress presses one or more keys (POST /director/keyboard/press).
+func (c *Client) KeyboardPress(ctx context.Context, keys ...string) error {
+	body := map[string]any{"keys": keys}
+	return c.doSimple(ctx, http.MethodPost, "/director/keyboard/press", body, http.StatusOK)
+}
+
+// KeyboardHold holds a key down (POST /director/keyboard/hold).
+func (c *Client) KeyboardHold(ctx context.Context, key string) error {
+	body := map[string]any{"key": key}
+	return c.doSimple(ctx, http.MethodPost, "/director/keyboard/hold", body, http.StatusOK)
+}
+
+// KeyboardRelease releases a held key (POST /director/keyboard/release).
+func (c *Client) KeyboardRelease(ctx context.Context, key string) error {
+	body := map[string]any{"key": key}
+	return c.doSimple(ctx, http.MethodPost, "/director/keyboard/release", body, http.StatusOK)
+}
+
+// ---------------------------------------------------------------------------
+// Director — Window
+// ---------------------------------------------------------------------------
+
+// WindowFind finds a window by name or WM_CLASS
+// (POST /director/window/find).
+func (c *Client) WindowFind(ctx context.Context, req WindowFindRequest) (*WindowInfo, error) {
+	if req.Timeout == 0 {
+		req.Timeout = 10.0
+	}
+	var info WindowInfo
+	if err := c.doJSON(ctx, http.MethodPost, "/director/window/find", req, http.StatusOK, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// WindowFocus focuses a window (POST /director/window/{id}/focus).
+func (c *Client) WindowFocus(ctx context.Context, windowID string) error {
+	return c.doSimple(ctx, http.MethodPost, "/director/window/"+windowID+"/focus", nil, http.StatusOK)
+}
+
+// WindowMove moves a window (POST /director/window/{id}/move).
+func (c *Client) WindowMove(ctx context.Context, windowID string, x, y int) error {
+	body := map[string]any{"x": x, "y": y}
+	return c.doSimple(ctx, http.MethodPost, "/director/window/"+windowID+"/move", body, http.StatusOK)
+}
+
+// WindowResize resizes a window (POST /director/window/{id}/resize).
+func (c *Client) WindowResize(ctx context.Context, windowID string, width, height int) error {
+	body := map[string]any{"width": width, "height": height}
+	return c.doSimple(ctx, http.MethodPost, "/director/window/"+windowID+"/resize", body, http.StatusOK)
+}
+
+// WindowMinimize minimizes a window (POST /director/window/{id}/minimize).
+func (c *Client) WindowMinimize(ctx context.Context, windowID string) error {
+	return c.doSimple(ctx, http.MethodPost, "/director/window/"+windowID+"/minimize", nil, http.StatusOK)
+}
+
+// WindowGeometry returns the geometry of a window
+// (GET /director/window/{id}/geometry).
+func (c *Client) WindowGeometry(ctx context.Context, windowID string) (*WindowGeometryInfo, error) {
+	var geo WindowGeometryInfo
+	if err := c.doJSON(ctx, http.MethodGet, "/director/window/"+windowID+"/geometry", nil, http.StatusOK, &geo); err != nil {
+		return nil, err
+	}
+	return &geo, nil
+}
+
+// WindowTile tiles windows (POST /director/window/tile).
+func (c *Client) WindowTile(ctx context.Context, req WindowTileRequest) error {
+	return c.doSimple(ctx, http.MethodPost, "/director/window/tile", req, http.StatusOK)
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+// doRawGet performs a GET request and returns the raw response bytes. It
+// constructs the URL directly (no path.Clean) so query strings are preserved.
+func (c *Client) doRawGet(ctx context.Context, rawPath string) ([]byte, error) {
+	if err := c.ensureReady(ctx); err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+rawPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, &RecorderError{StatusCode: resp.StatusCode, Status: resp.Status, Body: string(b)}
+	}
+	return io.ReadAll(resp.Body)
+}
 
 func (c *Client) doSimple(ctx context.Context, method, urlPath string, body any, wantStatus int) error {
 	resp, err := c.doRequest(ctx, method, urlPath, body)

--- a/sdks/go/thea/recorder_test.go
+++ b/sdks/go/thea/recorder_test.go
@@ -154,6 +154,11 @@ func fakeServer() *httptest.Server {
 	})
 	mux.HandleFunc("/recordings/", func(w http.ResponseWriter, r *http.Request) {
 		rest := strings.TrimPrefix(r.URL.Path, "/recordings/")
+		if strings.Contains(rest, "/screenshot") {
+			w.Header().Set("Content-Type", "image/jpeg")
+			w.Write([]byte("fake-recording-jpeg"))
+			return
+		}
 		if strings.HasSuffix(rest, "/info") {
 			name := strings.TrimSuffix(rest, "/info")
 			json.NewEncoder(w).Encode(thea.RecordingInfo{
@@ -226,6 +231,180 @@ func fakeServer() *httptest.Server {
 			w.WriteHeader(http.StatusOK)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// Display screenshot & stream
+	mux.HandleFunc("/display/screenshot", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("fake-jpeg-data"))
+	})
+	mux.HandleFunc("/display/stream", func(w http.ResponseWriter, r *http.Request) {
+		// Not actually called in tests, just registered for completeness.
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/display/view", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Annotations
+	var annotations []thea.Annotation
+	var annMu sync.Mutex
+
+	mux.HandleFunc("/recording/annotations", func(w http.ResponseWriter, r *http.Request) {
+		annMu.Lock()
+		defer annMu.Unlock()
+		switch r.Method {
+		case http.MethodPost:
+			var req thea.AddAnnotationRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			ann := thea.Annotation{Label: req.Label, Time: 1.5, Details: req.Details}
+			if req.Time != nil {
+				ann.Time = *req.Time
+			}
+			annotations = append(annotations, ann)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(ann)
+		case http.MethodGet:
+			if annotations == nil {
+				annotations = []thea.Annotation{}
+			}
+			json.NewEncoder(w).Encode(annotations)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// Events
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		events := []thea.Event{
+			{Event: "display_started", Time: "2025-01-01T00:00:00Z", Elapsed: 0.0, Details: map[string]any{"display": ":99"}},
+			{Event: "recording_started", Time: "2025-01-01T00:00:01Z", Elapsed: 1.0},
+		}
+		sinceStr := r.URL.Query().Get("since")
+		if sinceStr != "" {
+			// Simple filter: return only the second event.
+			events = events[1:]
+		}
+		json.NewEncoder(w).Encode(events)
+	})
+
+	// Director — Mouse
+	mux.HandleFunc("/director/mouse/move", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/mouse/click", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/mouse/double-click", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/mouse/right-click", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/mouse/drag", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/mouse/scroll", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/mouse/position", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(thea.MousePos{X: 100, Y: 200})
+	})
+
+	// Director — Keyboard
+	mux.HandleFunc("/director/keyboard/type", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/keyboard/press", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/keyboard/hold", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/keyboard/release", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Director — Window
+	mux.HandleFunc("/director/window/find", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		json.NewEncoder(w).Encode(thea.WindowInfo{WindowID: "12345", Name: "xterm", Class: "XTerm"})
+	})
+	mux.HandleFunc("/director/window/tile", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/director/window/", func(w http.ResponseWriter, r *http.Request) {
+		// Handle /director/window/{id}/focus, /move, /resize, /minimize, /geometry
+		rest := strings.TrimPrefix(r.URL.Path, "/director/window/")
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) < 2 {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		action := parts[1]
+		switch action {
+		case "focus", "move", "resize", "minimize":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case "geometry":
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			json.NewEncoder(w).Encode(thea.WindowGeometryInfo{X: 0, Y: 0, Width: 1280, Height: 720})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
 		}
 	})
 
@@ -795,6 +974,408 @@ func TestCreateCompositionAndWait_AlreadyExists(t *testing.T) {
 	}
 	if status.Status != "complete" {
 		t.Fatalf("expected status 'complete', got %q", status.Status)
+	}
+}
+
+func TestCreateCompositionAndWait_Accepted(t *testing.T) {
+	// Server that returns 202 Accepted for composition creation.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/compositions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			http.Error(w, `{"status":"accepted"}`, http.StatusAccepted)
+			return
+		}
+	})
+	mux.HandleFunc("/compositions/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(thea.CompositionStatus{
+			Name:   "async-comp",
+			Status: "complete",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	c := thea.NewClient(ts.URL)
+	ctx := context.Background()
+
+	req := thea.CompositionRequest{
+		Name:       "async-comp",
+		Recordings: []string{"a", "b"},
+	}
+	status, err := c.CreateCompositionAndWait(ctx, req, 5*time.Second)
+	if err != nil {
+		t.Fatalf("CreateCompositionAndWait with 202: %v", err)
+	}
+	if status.Status != "complete" {
+		t.Fatalf("expected status 'complete', got %q", status.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Display screenshot / URL tests
+// ---------------------------------------------------------------------------
+
+func TestDisplayScreenshot(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	data, err := c.DisplayScreenshot(context.Background(), 80)
+	if err != nil {
+		t.Fatalf("DisplayScreenshot: %v", err)
+	}
+	if string(data) != "fake-jpeg-data" {
+		t.Fatalf("unexpected data: %q", string(data))
+	}
+}
+
+func TestDisplayStreamURL(t *testing.T) {
+	c := thea.NewClient("http://localhost:9123")
+	url := c.DisplayStreamURL(10)
+	want := "http://localhost:9123/display/stream?fps=10"
+	if url != want {
+		t.Fatalf("expected %q, got %q", want, url)
+	}
+}
+
+func TestDisplayViewerURL(t *testing.T) {
+	c := thea.NewClient("http://localhost:9123")
+	url := c.DisplayViewerURL()
+	want := "http://localhost:9123/display/view"
+	if url != want {
+		t.Fatalf("expected %q, got %q", want, url)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Annotation tests
+// ---------------------------------------------------------------------------
+
+func TestAnnotationLifecycle(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+	ctx := context.Background()
+
+	timeVal := 2.5
+	ann, err := c.AddAnnotation(ctx, thea.AddAnnotationRequest{
+		Label:   "step_1",
+		Time:    &timeVal,
+		Details: "first step",
+	})
+	if err != nil {
+		t.Fatalf("AddAnnotation: %v", err)
+	}
+	if ann.Label != "step_1" {
+		t.Fatalf("expected label 'step_1', got %q", ann.Label)
+	}
+	if ann.Time != 2.5 {
+		t.Fatalf("expected time 2.5, got %f", ann.Time)
+	}
+
+	anns, err := c.ListAnnotations(ctx)
+	if err != nil {
+		t.Fatalf("ListAnnotations: %v", err)
+	}
+	if len(anns) != 1 {
+		t.Fatalf("expected 1 annotation, got %d", len(anns))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Events tests
+// ---------------------------------------------------------------------------
+
+func TestEvents(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+	ctx := context.Background()
+
+	events, err := c.Events(ctx)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Event != "display_started" {
+		t.Fatalf("expected 'display_started', got %q", events[0].Event)
+	}
+}
+
+func TestEventsSince(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+	ctx := context.Background()
+
+	events, err := c.Events(ctx, 0.5)
+	if err != nil {
+		t.Fatalf("Events(since): %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Event != "recording_started" {
+		t.Fatalf("expected 'recording_started', got %q", events[0].Event)
+	}
+}
+
+func TestDashboardURL(t *testing.T) {
+	c := thea.NewClient("http://localhost:9123")
+	url := c.DashboardURL()
+	want := "http://localhost:9123/dashboard"
+	if url != want {
+		t.Fatalf("expected %q, got %q", want, url)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Recording screenshot tests
+// ---------------------------------------------------------------------------
+
+func TestRecordingScreenshot(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	data, err := c.RecordingScreenshot(context.Background(), "demo", 1.5, 80)
+	if err != nil {
+		t.Fatalf("RecordingScreenshot: %v", err)
+	}
+	if string(data) != "fake-recording-jpeg" {
+		t.Fatalf("unexpected data: %q", string(data))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Director — Mouse tests
+// ---------------------------------------------------------------------------
+
+func TestMouseMove(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.MouseMove(context.Background(), thea.MouseMoveRequest{X: 100, Y: 200})
+	if err != nil {
+		t.Fatalf("MouseMove: %v", err)
+	}
+}
+
+func TestMouseClick(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.MouseClick(context.Background(), thea.MouseClickRequest{Button: 1})
+	if err != nil {
+		t.Fatalf("MouseClick: %v", err)
+	}
+}
+
+func TestMouseDoubleClick(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	x, y := 50, 60
+	err := c.MouseDoubleClick(context.Background(), &x, &y)
+	if err != nil {
+		t.Fatalf("MouseDoubleClick: %v", err)
+	}
+}
+
+func TestMouseRightClick(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.MouseRightClick(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("MouseRightClick: %v", err)
+	}
+}
+
+func TestMouseDrag(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.MouseDrag(context.Background(), thea.MouseDragRequest{
+		StartX: 10, StartY: 20, EndX: 300, EndY: 400,
+	})
+	if err != nil {
+		t.Fatalf("MouseDrag: %v", err)
+	}
+}
+
+func TestMouseScroll(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.MouseScroll(context.Background(), thea.MouseScrollRequest{Clicks: 3})
+	if err != nil {
+		t.Fatalf("MouseScroll: %v", err)
+	}
+}
+
+func TestMousePosition(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	pos, err := c.MousePosition(context.Background())
+	if err != nil {
+		t.Fatalf("MousePosition: %v", err)
+	}
+	if pos.X != 100 || pos.Y != 200 {
+		t.Fatalf("expected (100,200), got (%d,%d)", pos.X, pos.Y)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Director — Keyboard tests
+// ---------------------------------------------------------------------------
+
+func TestKeyboardType(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.KeyboardType(context.Background(), thea.KeyboardTypeRequest{Text: "hello"})
+	if err != nil {
+		t.Fatalf("KeyboardType: %v", err)
+	}
+}
+
+func TestKeyboardPress(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.KeyboardPress(context.Background(), "Return", "Tab")
+	if err != nil {
+		t.Fatalf("KeyboardPress: %v", err)
+	}
+}
+
+func TestKeyboardHold(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.KeyboardHold(context.Background(), "Shift_L")
+	if err != nil {
+		t.Fatalf("KeyboardHold: %v", err)
+	}
+}
+
+func TestKeyboardRelease(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.KeyboardRelease(context.Background(), "Shift_L")
+	if err != nil {
+		t.Fatalf("KeyboardRelease: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Director — Window tests
+// ---------------------------------------------------------------------------
+
+func TestWindowFind(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	info, err := c.WindowFind(context.Background(), thea.WindowFindRequest{Name: "xterm"})
+	if err != nil {
+		t.Fatalf("WindowFind: %v", err)
+	}
+	if info.WindowID != "12345" {
+		t.Fatalf("expected window_id '12345', got %q", info.WindowID)
+	}
+	if info.Name != "xterm" {
+		t.Fatalf("expected name 'xterm', got %q", info.Name)
+	}
+}
+
+func TestWindowFocus(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.WindowFocus(context.Background(), "12345")
+	if err != nil {
+		t.Fatalf("WindowFocus: %v", err)
+	}
+}
+
+func TestWindowMove(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.WindowMove(context.Background(), "12345", 100, 200)
+	if err != nil {
+		t.Fatalf("WindowMove: %v", err)
+	}
+}
+
+func TestWindowResize(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.WindowResize(context.Background(), "12345", 1280, 720)
+	if err != nil {
+		t.Fatalf("WindowResize: %v", err)
+	}
+}
+
+func TestWindowMinimize(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.WindowMinimize(context.Background(), "12345")
+	if err != nil {
+		t.Fatalf("WindowMinimize: %v", err)
+	}
+}
+
+func TestWindowGeometry(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	geo, err := c.WindowGeometry(context.Background(), "12345")
+	if err != nil {
+		t.Fatalf("WindowGeometry: %v", err)
+	}
+	if geo.Width != 1280 || geo.Height != 720 {
+		t.Fatalf("expected 1280x720, got %dx%d", geo.Width, geo.Height)
+	}
+}
+
+func TestWindowTile(t *testing.T) {
+	ts := fakeServer()
+	defer ts.Close()
+	c := newTestClient(ts)
+
+	err := c.WindowTile(context.Background(), thea.WindowTileRequest{
+		WindowIDs: []string{"12345", "67890"},
+		Layout:    "side-by-side",
+	})
+	if err != nil {
+		t.Fatalf("WindowTile: %v", err)
 	}
 }
 

--- a/sdks/java/src/main/java/com/recorder/RecorderClient.java
+++ b/sdks/java/src/main/java/com/recorder/RecorderClient.java
@@ -92,6 +92,35 @@ public class RecorderClient implements AutoCloseable {
         post("/display/stop", "", 200);
     }
 
+    /**
+     * Captures a JPEG screenshot of the live display.
+     *
+     * @param quality JPEG quality (1-100)
+     * @return JPEG image data
+     */
+    public byte[] displayScreenshot(int quality) {
+        return getRaw("/display/screenshot?quality=" + quality, 200);
+    }
+
+    /**
+     * Returns the URL for the live MJPEG stream.
+     *
+     * @param fps frames per second for the stream (1-15)
+     * @return full URL to the MJPEG stream endpoint
+     */
+    public String displayStreamUrl(int fps) {
+        return baseUrl + "/display/stream?fps=" + fps;
+    }
+
+    /**
+     * Returns the URL for the HTML live viewer page.
+     *
+     * @return full URL to the viewer page
+     */
+    public String displayViewerUrl() {
+        return baseUrl + "/display/view";
+    }
+
     // ── Panels ───────────────────────────────────────────────────────────
 
     /**
@@ -246,6 +275,39 @@ public class RecorderClient implements AutoCloseable {
         return stopRecording();
     }
 
+    // ── Annotations ─────────────────────────────────────────────────────
+
+    /**
+     * Adds an annotation to the active recording.
+     *
+     * @param label   short label for the annotation
+     * @param time    time offset in seconds (null to use current elapsed time)
+     * @param details optional longer description (null to omit)
+     * @return the created annotation as a map
+     */
+    public Map<String, Object> addAnnotation(String label, Double time, String details) {
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("label", jsonString(label));
+        if (time != null) {
+            fields.put("time", String.valueOf(time));
+        }
+        if (details != null) {
+            fields.put("details", jsonString(details));
+        }
+        var json = post("/recording/annotations", jsonObject(fields), 201);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Lists annotations for the active recording.
+     *
+     * @return list of annotation maps
+     */
+    public List<Map<String, Object>> listAnnotations() {
+        var json = get("/recording/annotations", 200);
+        return parseJsonArray(json);
+    }
+
     // ── Recordings ───────────────────────────────────────────────────────
 
     /**
@@ -318,6 +380,45 @@ public class RecorderClient implements AutoCloseable {
     public RecordingInfo recordingInfo(String name) {
         var json = get("/recordings/" + encode(name) + "/info", 200);
         return parseRecordingInfo(json);
+    }
+
+    /**
+     * Extracts a JPEG frame from a saved recording.
+     *
+     * @param name       recording name
+     * @param timeOffset time offset in seconds into the video
+     * @param quality    JPEG quality (1-100)
+     * @return JPEG image data
+     */
+    public byte[] recordingScreenshot(String name, double timeOffset, int quality) {
+        var params = "?t=" + String.format("%.3f", timeOffset) + "&quality=" + quality;
+        return getRaw("/recordings/" + encode(name) + "/screenshot" + params, 200);
+    }
+
+    // ── Events ──────────────────────────────────────────────────────────
+
+    /**
+     * Returns the event log for the current session.
+     *
+     * @param since only return events with elapsed greater than this value (null for all)
+     * @return list of event maps
+     */
+    public List<Map<String, Object>> events(Double since) {
+        var path = "/events";
+        if (since != null) {
+            path = "/events?since=" + since;
+        }
+        var json = get(path, 200);
+        return parseJsonArray(json);
+    }
+
+    /**
+     * Returns the URL for the HTML dashboard page.
+     *
+     * @return full URL to the dashboard
+     */
+    public String dashboardUrl() {
+        return baseUrl + "/dashboard";
     }
 
     // ── Sessions ─────────────────────────────────────────────────────────
@@ -510,6 +611,330 @@ public class RecorderClient implements AutoCloseable {
         throw new RecorderError("Composition not ready after " + timeoutMs + "ms");
     }
 
+    // ── Director — Mouse ──────────────────────────────────────────────
+
+    /**
+     * Moves the mouse cursor.
+     *
+     * @param x           target X coordinate
+     * @param y           target Y coordinate
+     * @param duration    movement duration in seconds (null for default)
+     * @param targetWidth target width for Fitts's Law (null for default)
+     * @return response map
+     */
+    public Map<String, Object> mouseMove(int x, int y, Double duration, Double targetWidth) {
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("x", String.valueOf(x));
+        fields.put("y", String.valueOf(y));
+        if (duration != null) {
+            fields.put("duration", String.valueOf(duration));
+        }
+        if (targetWidth != null) {
+            fields.put("target_width", String.valueOf(targetWidth));
+        }
+        var json = post("/director/mouse/move", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Clicks the mouse.
+     *
+     * @param x        X coordinate (null to click at current position)
+     * @param y        Y coordinate (null to click at current position)
+     * @param button   mouse button (1=left, 2=middle, 3=right)
+     * @param duration movement duration in seconds (null for default)
+     * @return response map
+     */
+    public Map<String, Object> mouseClick(Integer x, Integer y, int button, Double duration) {
+        var fields = new LinkedHashMap<String, String>();
+        if (x != null) {
+            fields.put("x", String.valueOf(x));
+        }
+        if (y != null) {
+            fields.put("y", String.valueOf(y));
+        }
+        fields.put("button", String.valueOf(button));
+        if (duration != null) {
+            fields.put("duration", String.valueOf(duration));
+        }
+        var json = post("/director/mouse/click", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Double-clicks the mouse.
+     *
+     * @param x X coordinate (null to click at current position)
+     * @param y Y coordinate (null to click at current position)
+     * @return response map
+     */
+    public Map<String, Object> mouseDoubleClick(Integer x, Integer y) {
+        var fields = new LinkedHashMap<String, String>();
+        if (x != null) {
+            fields.put("x", String.valueOf(x));
+        }
+        if (y != null) {
+            fields.put("y", String.valueOf(y));
+        }
+        var json = post("/director/mouse/double-click", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Right-clicks the mouse.
+     *
+     * @param x X coordinate (null to click at current position)
+     * @param y Y coordinate (null to click at current position)
+     * @return response map
+     */
+    public Map<String, Object> mouseRightClick(Integer x, Integer y) {
+        var fields = new LinkedHashMap<String, String>();
+        if (x != null) {
+            fields.put("x", String.valueOf(x));
+        }
+        if (y != null) {
+            fields.put("y", String.valueOf(y));
+        }
+        var json = post("/director/mouse/right-click", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Drags from one point to another.
+     *
+     * @param startX   start X coordinate
+     * @param startY   start Y coordinate
+     * @param endX     end X coordinate
+     * @param endY     end Y coordinate
+     * @param button   mouse button (1=left, 2=middle, 3=right)
+     * @param duration movement duration in seconds (null for default)
+     * @return response map
+     */
+    public Map<String, Object> mouseDrag(int startX, int startY, int endX, int endY, int button, Double duration) {
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("start_x", String.valueOf(startX));
+        fields.put("start_y", String.valueOf(startY));
+        fields.put("end_x", String.valueOf(endX));
+        fields.put("end_y", String.valueOf(endY));
+        fields.put("button", String.valueOf(button));
+        if (duration != null) {
+            fields.put("duration", String.valueOf(duration));
+        }
+        var json = post("/director/mouse/drag", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Scrolls the mouse wheel.
+     *
+     * @param clicks number of scroll clicks (positive=up, negative=down)
+     * @param x      X coordinate (null for current position)
+     * @param y      Y coordinate (null for current position)
+     * @return response map
+     */
+    public Map<String, Object> mouseScroll(int clicks, Integer x, Integer y) {
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("clicks", String.valueOf(clicks));
+        if (x != null) {
+            fields.put("x", String.valueOf(x));
+        }
+        if (y != null) {
+            fields.put("y", String.valueOf(y));
+        }
+        var json = post("/director/mouse/scroll", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Gets the current mouse cursor position.
+     *
+     * @return map with "x" and "y" keys
+     */
+    public Map<String, Object> mousePosition() {
+        var json = get("/director/mouse/position", 200);
+        return parseJsonObject(json);
+    }
+
+    // ── Director — Keyboard ────────────────────────────────────────────
+
+    /**
+     * Types text with human-like rhythm.
+     *
+     * @param text text to type
+     * @param wpm  words per minute (null for default)
+     * @return response map
+     */
+    public Map<String, Object> keyboardType(String text, Double wpm) {
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("text", jsonString(text));
+        if (wpm != null) {
+            fields.put("wpm", String.valueOf(wpm));
+        }
+        var json = post("/director/keyboard/type", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Presses one or more keys.
+     *
+     * @param keys key names to press
+     * @return response map
+     */
+    public Map<String, Object> keyboardPress(String... keys) {
+        var keysArray = new StringBuilder("[");
+        for (int i = 0; i < keys.length; i++) {
+            if (i > 0) keysArray.append(",");
+            keysArray.append(jsonString(keys[i]));
+        }
+        keysArray.append("]");
+        var body = "{\"keys\":" + keysArray + "}";
+        var json = post("/director/keyboard/press", body, 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Holds a key down.
+     *
+     * @param key key name to hold
+     * @return response map
+     */
+    public Map<String, Object> keyboardHold(String key) {
+        var body = jsonObject(Map.of("key", jsonString(key)));
+        var json = post("/director/keyboard/hold", body, 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Releases a held key.
+     *
+     * @param key key name to release
+     * @return response map
+     */
+    public Map<String, Object> keyboardRelease(String key) {
+        var body = jsonObject(Map.of("key", jsonString(key)));
+        var json = post("/director/keyboard/release", body, 200);
+        return parseJsonObject(json);
+    }
+
+    // ── Director — Window ──────────────────────────────────────────────
+
+    /**
+     * Finds a window by name or WM_CLASS.
+     *
+     * @param name      window name (null to search by class only)
+     * @param className WM_CLASS (null to search by name only)
+     * @param timeout   search timeout in seconds
+     * @return map with "window_id" key
+     */
+    public Map<String, Object> windowFind(String name, String className, double timeout) {
+        var fields = new LinkedHashMap<String, String>();
+        if (name != null) {
+            fields.put("name", jsonString(name));
+        }
+        if (className != null) {
+            fields.put("class", jsonString(className));
+        }
+        fields.put("timeout", String.valueOf(timeout));
+        var json = post("/director/window/find", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Focuses a window.
+     *
+     * @param windowId X11 window ID
+     * @return response map
+     */
+    public Map<String, Object> windowFocus(String windowId) {
+        var json = post("/director/window/" + encode(windowId) + "/focus", "", 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Moves a window.
+     *
+     * @param windowId X11 window ID
+     * @param x        target X coordinate
+     * @param y        target Y coordinate
+     * @return response map
+     */
+    public Map<String, Object> windowMove(String windowId, int x, int y) {
+        var body = jsonObject(new LinkedHashMap<>(Map.of(
+                "x", String.valueOf(x),
+                "y", String.valueOf(y)
+        )));
+        var json = post("/director/window/" + encode(windowId) + "/move", body, 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Resizes a window.
+     *
+     * @param windowId X11 window ID
+     * @param width    target width
+     * @param height   target height
+     * @return response map
+     */
+    public Map<String, Object> windowResize(String windowId, int width, int height) {
+        var body = jsonObject(new LinkedHashMap<>(Map.of(
+                "width", String.valueOf(width),
+                "height", String.valueOf(height)
+        )));
+        var json = post("/director/window/" + encode(windowId) + "/resize", body, 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Minimizes a window.
+     *
+     * @param windowId X11 window ID
+     * @return response map
+     */
+    public Map<String, Object> windowMinimize(String windowId) {
+        var json = post("/director/window/" + encode(windowId) + "/minimize", "", 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Gets window geometry.
+     *
+     * @param windowId X11 window ID
+     * @return map with "x", "y", "width", "height" keys
+     */
+    public Map<String, Object> windowGeometry(String windowId) {
+        var json = get("/director/window/" + encode(windowId) + "/geometry", 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Tiles windows in a layout.
+     *
+     * @param windowIds list of X11 window IDs
+     * @param layout    layout type (e.g. "side-by-side")
+     * @param bounds    optional bounding box [x, y, width, height] (null for display size)
+     * @return response map
+     */
+    public Map<String, Object> windowTile(List<String> windowIds, String layout, int[] bounds) {
+        var idsArray = new StringBuilder("[");
+        for (int i = 0; i < windowIds.size(); i++) {
+            if (i > 0) idsArray.append(",");
+            idsArray.append(jsonString(windowIds.get(i)));
+        }
+        idsArray.append("]");
+        var body = new StringBuilder("{\"window_ids\":").append(idsArray)
+                .append(",\"layout\":").append(jsonString(layout));
+        if (bounds != null) {
+            body.append(",\"bounds\":[")
+                    .append(bounds[0]).append(",")
+                    .append(bounds[1]).append(",")
+                    .append(bounds[2]).append(",")
+                    .append(bounds[3]).append("]");
+        }
+        body.append("}");
+        var json = post("/director/window/tile", body.toString(), 200);
+        return parseJsonObject(json);
+    }
+
     // ── Layout & Diagnostics ────────────────────────────────────────────
 
     /**
@@ -621,6 +1046,27 @@ public class RecorderClient implements AutoCloseable {
     private void delete(String path, int expectedStatus) {
         var request = newRequest(path).DELETE().build();
         send(request, expectedStatus);
+    }
+
+    private byte[] getRaw(String path, int expectedStatus) {
+        ensureReady(path);
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(timeout)
+                .GET()
+                .build();
+        try {
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() != expectedStatus) {
+                throw new RecorderError(response.statusCode(),
+                        "HTTP %d from GET %s".formatted(response.statusCode(), path));
+            }
+            return response.body();
+        } catch (RecorderError e) {
+            throw e;
+        } catch (IOException | InterruptedException e) {
+            throw new RecorderError("Request failed: GET " + path, e);
+        }
     }
 
     private synchronized void ensureReady(String path) {
@@ -915,6 +1361,110 @@ public class RecorderClient implements AutoCloseable {
                 jsonValue(json, "output_path"),
                 jsonValue(json, "error")
         );
+    }
+
+    /**
+     * Parses a flat JSON object into a Map. Values are strings, numbers, or booleans.
+     */
+    private Map<String, Object> parseJsonObject(String json) {
+        var result = new LinkedHashMap<String, Object>();
+        if (json == null || json.isBlank()) return result;
+        json = json.strip();
+        if (!json.startsWith("{") || !json.endsWith("}")) return result;
+        // Extract keys by scanning for "key": patterns
+        int idx = 1; // skip opening brace
+        while (idx < json.length() - 1) {
+            // skip whitespace
+            while (idx < json.length() && Character.isWhitespace(json.charAt(idx))) idx++;
+            if (idx >= json.length() - 1 || json.charAt(idx) == '}') break;
+            if (json.charAt(idx) == ',') { idx++; continue; }
+            // expect a quoted key
+            if (json.charAt(idx) != '"') break;
+            int keyStart = idx + 1;
+            int keyEnd = json.indexOf('"', keyStart);
+            if (keyEnd < 0) break;
+            String key = json.substring(keyStart, keyEnd);
+            idx = keyEnd + 1;
+            // skip colon and whitespace
+            while (idx < json.length() && (json.charAt(idx) == ':' || Character.isWhitespace(json.charAt(idx)))) idx++;
+            if (idx >= json.length()) break;
+            // parse value
+            char ch = json.charAt(idx);
+            if (ch == '"') {
+                // string value
+                int vStart = idx + 1;
+                int vEnd = vStart;
+                while (vEnd < json.length()) {
+                    if (json.charAt(vEnd) == '\\') { vEnd += 2; continue; }
+                    if (json.charAt(vEnd) == '"') break;
+                    vEnd++;
+                }
+                result.put(key, json.substring(vStart, vEnd));
+                idx = vEnd + 1;
+            } else if (ch == 'n' && json.startsWith("null", idx)) {
+                result.put(key, null);
+                idx += 4;
+            } else if (ch == 't' && json.startsWith("true", idx)) {
+                result.put(key, Boolean.TRUE);
+                idx += 4;
+            } else if (ch == 'f' && json.startsWith("false", idx)) {
+                result.put(key, Boolean.FALSE);
+                idx += 5;
+            } else if (ch == '[' || ch == '{') {
+                // skip nested structure
+                char open = ch;
+                char close = (ch == '[') ? ']' : '}';
+                int depth = 1;
+                int sStart = idx;
+                idx++;
+                boolean inStr = false;
+                while (idx < json.length() && depth > 0) {
+                    char c = json.charAt(idx);
+                    if (c == '\\' && inStr) { idx += 2; continue; }
+                    if (c == '"') inStr = !inStr;
+                    else if (!inStr) {
+                        if (c == open) depth++;
+                        else if (c == close) depth--;
+                    }
+                    idx++;
+                }
+                result.put(key, json.substring(sStart, idx));
+            } else {
+                // number
+                int vStart = idx;
+                while (idx < json.length() && json.charAt(idx) != ',' && json.charAt(idx) != '}'
+                        && !Character.isWhitespace(json.charAt(idx))) idx++;
+                String raw = json.substring(vStart, idx);
+                try {
+                    if (raw.contains(".")) {
+                        result.put(key, Double.parseDouble(raw));
+                    } else {
+                        long l = Long.parseLong(raw);
+                        if (l >= Integer.MIN_VALUE && l <= Integer.MAX_VALUE) {
+                            result.put(key, (int) l);
+                        } else {
+                            result.put(key, l);
+                        }
+                    }
+                } catch (NumberFormatException e) {
+                    result.put(key, raw);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Parses a JSON array of objects into a List of Maps.
+     */
+    private List<Map<String, Object>> parseJsonArray(String json) {
+        var result = new ArrayList<Map<String, Object>>();
+        if (json == null || json.isBlank()) return result;
+        var elements = jsonArrayElements(json);
+        for (var el : elements) {
+            result.add(parseJsonObject(el));
+        }
+        return result;
     }
 
     private List<RecordingInfo> parseRecordingInfoList(String json) {

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -107,6 +107,42 @@ export interface CreateCompositionRequest {
   highlight_width?: number;
 }
 
+/** An annotation on a recording. */
+export interface Annotation {
+  label: string;
+  time: number;
+  details?: string;
+}
+
+/** An event from the event log. */
+export interface Event {
+  event: string;
+  time: string;
+  elapsed: number;
+  details?: Record<string, unknown>;
+}
+
+/** Window information returned by windowFind. */
+export interface WindowInfo {
+  window_id: string;
+  name?: string;
+  class?: string;
+}
+
+/** Window geometry returned by windowGeometry. */
+export interface WindowGeometry {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Mouse position returned by mousePosition. */
+export interface MousePosition {
+  x: number;
+  y: number;
+}
+
 /** Response from composition endpoints. */
 export interface CompositionStatus {
   name: string;
@@ -265,6 +301,27 @@ export class RecorderClient {
     await this.request("POST", "/display/stop");
   }
 
+  /** Capture a JPEG screenshot of the live display (GET /display/screenshot). */
+  async displayScreenshot(quality = 80): Promise<Buffer> {
+    const res = await this.request(
+      "GET",
+      `/display/screenshot?quality=${quality}`,
+      undefined,
+      true,
+    );
+    return Buffer.from(await res.arrayBuffer());
+  }
+
+  /** Return the URL for the live MJPEG stream (no HTTP call). */
+  displayStreamUrl(fps = 5): string {
+    return `${this.baseUrl}/display/stream?fps=${fps}`;
+  }
+
+  /** Return the URL for the HTML live viewer page (no HTTP call). */
+  displayViewerUrl(): string {
+    return `${this.baseUrl}/display/view`;
+  }
+
   // -----------------------------------------------------------------------
   // Panels
   // -----------------------------------------------------------------------
@@ -311,6 +368,22 @@ export class RecorderClient {
   /** Get recording status (GET /recording/status). */
   async recordingStatus(): Promise<RecordingStatusResponse> {
     return this.request<RecordingStatusResponse>("GET", "/recording/status");
+  }
+
+  /** Add an annotation to the active recording (POST /recording/annotations). */
+  async addAnnotation(
+    label: string,
+    options?: { time?: number; details?: string },
+  ): Promise<Annotation> {
+    const body: Record<string, unknown> = { label };
+    if (options?.time !== undefined) body.time = options.time;
+    if (options?.details !== undefined) body.details = options.details;
+    return this.request<Annotation>("POST", "/recording/annotations", body);
+  }
+
+  /** List annotations for the active recording (GET /recording/annotations). */
+  async listAnnotations(): Promise<Annotation[]> {
+    return this.request<Annotation[]>("GET", "/recording/annotations");
   }
 
   // -----------------------------------------------------------------------
@@ -363,6 +436,37 @@ export class RecorderClient {
       "GET",
       `/recordings/${encodeURIComponent(name)}/info`,
     );
+  }
+
+  /** Extract a JPEG frame from a saved recording (GET /recordings/{name}/screenshot). */
+  async recordingScreenshot(
+    name: string,
+    timeOffset: number,
+    quality = 80,
+  ): Promise<Buffer> {
+    const params = `?t=${timeOffset.toFixed(3)}&quality=${quality}`;
+    const res = await this.request(
+      "GET",
+      `/recordings/${encodeURIComponent(name)}/screenshot${params}`,
+      undefined,
+      true,
+    );
+    return Buffer.from(await res.arrayBuffer());
+  }
+
+  // -----------------------------------------------------------------------
+  // Events
+  // -----------------------------------------------------------------------
+
+  /** Return the event log for the current session (GET /events). */
+  async events(since?: number): Promise<Event[]> {
+    const path = since !== undefined ? `/events?since=${since}` : "/events";
+    return this.request<Event[]>("GET", path);
+  }
+
+  /** Return the URL for the HTML dashboard page (no HTTP call). */
+  dashboardUrl(): string {
+    return `${this.baseUrl}/dashboard`;
   }
 
   // -----------------------------------------------------------------------
@@ -472,6 +576,186 @@ export class RecorderClient {
     throw new RecorderError(
       `Composition "${name}" not ready after ${timeout}ms`,
     );
+  }
+
+  // -----------------------------------------------------------------------
+  // Director — Mouse
+  // -----------------------------------------------------------------------
+
+  /** Move the mouse cursor (POST /director/mouse/move). */
+  async mouseMove(
+    x: number,
+    y: number,
+    options?: { duration?: number; targetWidth?: number },
+  ): Promise<void> {
+    const body: Record<string, unknown> = { x, y };
+    if (options?.duration !== undefined) body.duration = options.duration;
+    if (options?.targetWidth !== undefined) body.target_width = options.targetWidth;
+    await this.request("POST", "/director/mouse/move", body);
+  }
+
+  /** Click the mouse (POST /director/mouse/click). */
+  async mouseClick(options?: {
+    x?: number;
+    y?: number;
+    button?: number;
+    duration?: number;
+  }): Promise<void> {
+    const body: Record<string, unknown> = {};
+    if (options?.x !== undefined) body.x = options.x;
+    if (options?.y !== undefined) body.y = options.y;
+    if (options?.button !== undefined) body.button = options.button;
+    if (options?.duration !== undefined) body.duration = options.duration;
+    await this.request("POST", "/director/mouse/click", body);
+  }
+
+  /** Double-click the mouse (POST /director/mouse/double-click). */
+  async mouseDoubleClick(x?: number, y?: number): Promise<void> {
+    const body: Record<string, unknown> = {};
+    if (x !== undefined) body.x = x;
+    if (y !== undefined) body.y = y;
+    await this.request("POST", "/director/mouse/double-click", body);
+  }
+
+  /** Right-click the mouse (POST /director/mouse/right-click). */
+  async mouseRightClick(x?: number, y?: number): Promise<void> {
+    const body: Record<string, unknown> = {};
+    if (x !== undefined) body.x = x;
+    if (y !== undefined) body.y = y;
+    await this.request("POST", "/director/mouse/right-click", body);
+  }
+
+  /** Drag from one point to another (POST /director/mouse/drag). */
+  async mouseDrag(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    options?: { button?: number; duration?: number },
+  ): Promise<void> {
+    const body: Record<string, unknown> = {
+      start_x: startX,
+      start_y: startY,
+      end_x: endX,
+      end_y: endY,
+    };
+    if (options?.button !== undefined) body.button = options.button;
+    if (options?.duration !== undefined) body.duration = options.duration;
+    await this.request("POST", "/director/mouse/drag", body);
+  }
+
+  /** Scroll the mouse wheel (POST /director/mouse/scroll). */
+  async mouseScroll(clicks: number, x?: number, y?: number): Promise<void> {
+    const body: Record<string, unknown> = { clicks };
+    if (x !== undefined) body.x = x;
+    if (y !== undefined) body.y = y;
+    await this.request("POST", "/director/mouse/scroll", body);
+  }
+
+  /** Get cursor position (GET /director/mouse/position). */
+  async mousePosition(): Promise<MousePosition> {
+    return this.request<MousePosition>("GET", "/director/mouse/position");
+  }
+
+  // -----------------------------------------------------------------------
+  // Director — Keyboard
+  // -----------------------------------------------------------------------
+
+  /** Type text with human-like rhythm (POST /director/keyboard/type). */
+  async keyboardType(text: string, wpm?: number): Promise<void> {
+    const body: Record<string, unknown> = { text };
+    if (wpm !== undefined) body.wpm = wpm;
+    await this.request("POST", "/director/keyboard/type", body);
+  }
+
+  /** Press key(s) (POST /director/keyboard/press). */
+  async keyboardPress(...keys: string[]): Promise<void> {
+    await this.request("POST", "/director/keyboard/press", { keys });
+  }
+
+  /** Hold a key down (POST /director/keyboard/hold). */
+  async keyboardHold(key: string): Promise<void> {
+    await this.request("POST", "/director/keyboard/hold", { key });
+  }
+
+  /** Release a held key (POST /director/keyboard/release). */
+  async keyboardRelease(key: string): Promise<void> {
+    await this.request("POST", "/director/keyboard/release", { key });
+  }
+
+  // -----------------------------------------------------------------------
+  // Director — Window
+  // -----------------------------------------------------------------------
+
+  /** Find a window by name or WM_CLASS (POST /director/window/find). */
+  async windowFind(options: {
+    name?: string;
+    className?: string;
+    timeout?: number;
+  }): Promise<WindowInfo> {
+    const body: Record<string, unknown> = {};
+    if (options.name !== undefined) body.name = options.name;
+    if (options.className !== undefined) body.class = options.className;
+    if (options.timeout !== undefined) body.timeout = options.timeout;
+    return this.request<WindowInfo>("POST", "/director/window/find", body);
+  }
+
+  /** Focus a window (POST /director/window/{id}/focus). */
+  async windowFocus(windowId: string): Promise<void> {
+    await this.request(
+      "POST",
+      `/director/window/${encodeURIComponent(windowId)}/focus`,
+    );
+  }
+
+  /** Move a window (POST /director/window/{id}/move). */
+  async windowMove(windowId: string, x: number, y: number): Promise<void> {
+    await this.request(
+      "POST",
+      `/director/window/${encodeURIComponent(windowId)}/move`,
+      { x, y },
+    );
+  }
+
+  /** Resize a window (POST /director/window/{id}/resize). */
+  async windowResize(
+    windowId: string,
+    width: number,
+    height: number,
+  ): Promise<void> {
+    await this.request(
+      "POST",
+      `/director/window/${encodeURIComponent(windowId)}/resize`,
+      { width, height },
+    );
+  }
+
+  /** Minimize a window (POST /director/window/{id}/minimize). */
+  async windowMinimize(windowId: string): Promise<void> {
+    await this.request(
+      "POST",
+      `/director/window/${encodeURIComponent(windowId)}/minimize`,
+    );
+  }
+
+  /** Get window geometry (GET /director/window/{id}/geometry). */
+  async windowGeometry(windowId: string): Promise<WindowGeometry> {
+    return this.request<WindowGeometry>(
+      "GET",
+      `/director/window/${encodeURIComponent(windowId)}/geometry`,
+    );
+  }
+
+  /** Tile windows (POST /director/window/tile). */
+  async windowTile(
+    windowIds: string[],
+    layout?: string,
+    bounds?: number[],
+  ): Promise<void> {
+    const body: Record<string, unknown> = { window_ids: windowIds };
+    if (layout !== undefined) body.layout = layout;
+    if (bounds !== undefined) body.bounds = bounds;
+    await this.request("POST", "/director/window/tile", body);
   }
 
   // -----------------------------------------------------------------------

--- a/sdks/python/thea/client.py
+++ b/sdks/python/thea/client.py
@@ -204,6 +204,46 @@ class RecorderClient:
         """POST /display/stop — stop the virtual display."""
         return self._request("POST", "/display/stop")
 
+    def display_screenshot(self, *, quality: int = 80) -> bytes:
+        """GET /display/screenshot — capture a JPEG screenshot of the live display.
+
+        Parameters
+        ----------
+        quality:
+            JPEG quality (1-100, default 80).
+
+        Returns
+        -------
+        bytes
+            JPEG image data.
+        """
+        return self._request_raw("GET", f"/display/screenshot?quality={quality}")
+
+    def display_stream_url(self, *, fps: int = 5) -> str:
+        """Return the URL for the live MJPEG stream.
+
+        Parameters
+        ----------
+        fps:
+            Frames per second for the stream (1-15, default 5).
+
+        Returns
+        -------
+        str
+            Full URL to the MJPEG stream endpoint.
+        """
+        return f"{self.base_url}{self._session_prefix}/display/stream?fps={fps}"
+
+    def display_viewer_url(self) -> str:
+        """Return the URL for the HTML live viewer page.
+
+        Returns
+        -------
+        str
+            Full URL to the viewer page.
+        """
+        return f"{self.base_url}{self._session_prefix}/display/view"
+
     # ------------------------------------------------------------------
     # Panels
     # ------------------------------------------------------------------
@@ -259,6 +299,51 @@ class RecorderClient:
         """GET /recording/status — full recording status."""
         return self._request("GET", "/recording/status")
 
+    def add_annotation(
+        self,
+        label: str,
+        *,
+        time: float | None = None,
+        details: str | None = None,
+    ) -> dict[str, Any]:
+        """POST /recording/annotations — add an annotation to the active recording.
+
+        Parameters
+        ----------
+        label:
+            Short label for the annotation (e.g. ``"login_started"``).
+        time:
+            Time offset in seconds into the recording.  *None* uses the
+            current recording elapsed time.
+        details:
+            Optional longer description.
+
+        Returns
+        -------
+        dict
+            The created annotation with ``label``, ``time``, and
+            optional ``details``.
+        """
+        body: dict[str, Any] = {"label": label}
+        if time is not None:
+            body["time"] = time
+        if details is not None:
+            body["details"] = details
+        return self._request("POST", "/recording/annotations", body)
+
+    def list_annotations(self) -> list[dict[str, Any]]:
+        """GET /recording/annotations — list annotations for the active recording.
+
+        Returns
+        -------
+        list
+            List of annotation dicts.
+        """
+        result = self._request("GET", "/recording/annotations")
+        if isinstance(result, list):
+            return result  # type: ignore[return-value]
+        return []
+
     # ------------------------------------------------------------------
     # Recordings archive
     # ------------------------------------------------------------------
@@ -285,6 +370,65 @@ class RecorderClient:
         """GET /recordings/{name}/info — metadata for a recording."""
         return self._request("GET", f"/recordings/{name}/info")
 
+    def recording_screenshot(
+        self, name: str, time_offset: float, *, quality: int = 80
+    ) -> bytes:
+        """GET /recordings/{name}/screenshot?t=...&quality=... — extract a frame.
+
+        Parameters
+        ----------
+        name:
+            Recording name.
+        time_offset:
+            Time offset in seconds into the video.
+        quality:
+            JPEG quality (1-100, default 80).
+
+        Returns
+        -------
+        bytes
+            JPEG image data.
+        """
+        params = f"?t={time_offset:.3f}&quality={quality}"
+        return self._request_raw("GET", f"/recordings/{name}/screenshot{params}")
+
+    # ------------------------------------------------------------------
+    # Events
+    # ------------------------------------------------------------------
+
+    def events(self, *, since: float | None = None) -> list[dict[str, Any]]:
+        """GET /events — return the event log for the current session.
+
+        Parameters
+        ----------
+        since:
+            Only return events with ``elapsed`` greater than this value.
+            Useful for polling for new events.
+
+        Returns
+        -------
+        list
+            List of event dicts with ``event``, ``time``, ``elapsed``,
+            and optional ``details`` keys.
+        """
+        path = "/events"
+        if since is not None:
+            path = f"/events?since={since}"
+        result = self._request("GET", path)
+        if isinstance(result, list):
+            return result  # type: ignore[return-value]
+        return []
+
+    def dashboard_url(self) -> str:
+        """Return the URL for the HTML dashboard page.
+
+        Returns
+        -------
+        str
+            Full URL to the dashboard.
+        """
+        return f"{self.base_url}/dashboard"
+
     # ------------------------------------------------------------------
     # Health / cleanup
     # ------------------------------------------------------------------
@@ -296,6 +440,30 @@ class RecorderClient:
     def cleanup(self) -> dict[str, Any]:
         """POST /cleanup — remove temporary resources."""
         return self._request("POST", "/cleanup")
+
+    # ------------------------------------------------------------------
+    # Layout validation
+    # ------------------------------------------------------------------
+
+    def validate_layout(self) -> dict[str, Any]:
+        """GET /validate-layout — validate the current panel layout.
+
+        Returns
+        -------
+        dict
+            ``{"warnings": [...], "valid": bool}``
+        """
+        return self._request("GET", "/validate-layout")
+
+    def testcard(self) -> str:
+        """GET /testcard — generate an SVG testcard of the current layout.
+
+        Returns
+        -------
+        str
+            SVG markup.
+        """
+        return self._request_raw("GET", "/testcard").decode("utf-8")
 
     # ------------------------------------------------------------------
     # Session management (parallel recordings)
@@ -456,6 +624,21 @@ class RecorderClient:
         """
         return self._request("GET", f"/compositions/{name}")
 
+    def delete_composition(self, name: str) -> dict[str, Any]:
+        """DELETE /compositions/{name} — delete a composition.
+
+        Parameters
+        ----------
+        name:
+            Name of the composition to delete.
+
+        Returns
+        -------
+        dict
+            Parsed JSON response from the server.
+        """
+        return self._request("DELETE", f"/compositions/{name}")
+
     def list_compositions(self) -> list[dict[str, Any]]:
         """GET /compositions — list all compositions.
 
@@ -567,6 +750,131 @@ class RecorderClient:
             highlight_width=highlight_width,
         )
         helper.result = self.wait_for_composition(name)
+
+    # ------------------------------------------------------------------
+    # Director — Mouse
+    # ------------------------------------------------------------------
+
+    def mouse_move(self, x: int, y: int, *, duration: float | None = None, target_width: float | None = None) -> dict[str, Any]:
+        """POST /director/mouse/move — move the mouse cursor."""
+        body: dict[str, Any] = {"x": x, "y": y}
+        if duration is not None:
+            body["duration"] = duration
+        if target_width is not None:
+            body["target_width"] = target_width
+        return self._request("POST", "/director/mouse/move", body)
+
+    def mouse_click(self, x: int | None = None, y: int | None = None, *, button: int = 1, duration: float | None = None) -> dict[str, Any]:
+        """POST /director/mouse/click — click the mouse."""
+        body: dict[str, Any] = {"button": button}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        if duration is not None:
+            body["duration"] = duration
+        return self._request("POST", "/director/mouse/click", body)
+
+    def mouse_double_click(self, x: int | None = None, y: int | None = None) -> dict[str, Any]:
+        """POST /director/mouse/double-click — double-click."""
+        body: dict[str, Any] = {}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        return self._request("POST", "/director/mouse/double-click", body)
+
+    def mouse_right_click(self, x: int | None = None, y: int | None = None) -> dict[str, Any]:
+        """POST /director/mouse/right-click — right-click."""
+        body: dict[str, Any] = {}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        return self._request("POST", "/director/mouse/right-click", body)
+
+    def mouse_drag(self, start_x: int, start_y: int, end_x: int, end_y: int, *, button: int = 1, duration: float | None = None) -> dict[str, Any]:
+        """POST /director/mouse/drag — drag from one point to another."""
+        body: dict[str, Any] = {"start_x": start_x, "start_y": start_y, "end_x": end_x, "end_y": end_y, "button": button}
+        if duration is not None:
+            body["duration"] = duration
+        return self._request("POST", "/director/mouse/drag", body)
+
+    def mouse_scroll(self, clicks: int, *, x: int | None = None, y: int | None = None) -> dict[str, Any]:
+        """POST /director/mouse/scroll — scroll the mouse wheel."""
+        body: dict[str, Any] = {"clicks": clicks}
+        if x is not None:
+            body["x"] = x
+        if y is not None:
+            body["y"] = y
+        return self._request("POST", "/director/mouse/scroll", body)
+
+    def mouse_position(self) -> dict[str, Any]:
+        """GET /director/mouse/position — get cursor position."""
+        return self._request("GET", "/director/mouse/position")
+
+    # ------------------------------------------------------------------
+    # Director — Keyboard
+    # ------------------------------------------------------------------
+
+    def keyboard_type(self, text: str, *, wpm: float | None = None) -> dict[str, Any]:
+        """POST /director/keyboard/type — type text with human-like rhythm."""
+        body: dict[str, Any] = {"text": text}
+        if wpm is not None:
+            body["wpm"] = wpm
+        return self._request("POST", "/director/keyboard/type", body)
+
+    def keyboard_press(self, *keys: str) -> dict[str, Any]:
+        """POST /director/keyboard/press — press key(s)."""
+        return self._request("POST", "/director/keyboard/press", {"keys": list(keys)})
+
+    def keyboard_hold(self, key: str) -> dict[str, Any]:
+        """POST /director/keyboard/hold — hold a key down."""
+        return self._request("POST", "/director/keyboard/hold", {"key": key})
+
+    def keyboard_release(self, key: str) -> dict[str, Any]:
+        """POST /director/keyboard/release — release a held key."""
+        return self._request("POST", "/director/keyboard/release", {"key": key})
+
+    # ------------------------------------------------------------------
+    # Director — Window
+    # ------------------------------------------------------------------
+
+    def window_find(self, name: str | None = None, *, class_name: str | None = None, timeout: float = 10.0) -> dict[str, Any]:
+        """POST /director/window/find — find a window by name or WM_CLASS."""
+        body: dict[str, Any] = {"timeout": timeout}
+        if name is not None:
+            body["name"] = name
+        if class_name is not None:
+            body["class"] = class_name
+        return self._request("POST", "/director/window/find", body)
+
+    def window_focus(self, window_id: str) -> dict[str, Any]:
+        """POST /director/window/{id}/focus — focus a window."""
+        return self._request("POST", f"/director/window/{window_id}/focus")
+
+    def window_move(self, window_id: str, x: int, y: int) -> dict[str, Any]:
+        """POST /director/window/{id}/move — move a window."""
+        return self._request("POST", f"/director/window/{window_id}/move", {"x": x, "y": y})
+
+    def window_resize(self, window_id: str, width: int, height: int) -> dict[str, Any]:
+        """POST /director/window/{id}/resize — resize a window."""
+        return self._request("POST", f"/director/window/{window_id}/resize", {"width": width, "height": height})
+
+    def window_minimize(self, window_id: str) -> dict[str, Any]:
+        """POST /director/window/{id}/minimize — minimize a window."""
+        return self._request("POST", f"/director/window/{window_id}/minimize")
+
+    def window_geometry(self, window_id: str) -> dict[str, Any]:
+        """GET /director/window/{id}/geometry — get window geometry."""
+        return self._request("GET", f"/director/window/{window_id}/geometry")
+
+    def window_tile(self, window_ids: list[str], layout: str = "side-by-side", *, bounds: tuple[int, int, int, int] | None = None) -> dict[str, Any]:
+        """POST /director/window/tile — tile windows."""
+        body: dict[str, Any] = {"window_ids": window_ids, "layout": layout}
+        if bounds is not None:
+            body["bounds"] = list(bounds)
+        return self._request("POST", "/director/window/tile", body)
 
     # ------------------------------------------------------------------
     # Convenience helpers

--- a/sdks/ruby/lib/recorder.rb
+++ b/sdks/ruby/lib/recorder.rb
@@ -30,6 +30,18 @@ module Recorder
       post("/display/stop")
     end
 
+    def display_screenshot(quality: 80)
+      raw_get("/display/screenshot?quality=#{quality}").body
+    end
+
+    def display_stream_url(fps: 5)
+      "#{@base_url}/display/stream?fps=#{fps}"
+    end
+
+    def display_viewer_url
+      "#{@base_url}/display/view"
+    end
+
     # Panels
 
     def add_panel(name:, title:, width: nil, height: nil)
@@ -78,6 +90,17 @@ module Recorder
       get("/recording/status")
     end
 
+    def add_annotation(label:, time: nil, details: nil)
+      body = { label: label }
+      body[:time] = time if time
+      body[:details] = details if details
+      post("/recording/annotations", body)
+    end
+
+    def list_annotations
+      get("/recording/annotations")
+    end
+
     def recording(name)
       start_recording(name: name)
       yield self
@@ -99,6 +122,22 @@ module Recorder
 
     def recording_info(name)
       get("/recordings/#{encode(name)}/info")
+    end
+
+    def recording_screenshot(name:, time:, quality: 80)
+      raw_get("/recordings/#{encode(name)}/screenshot?t=#{"%.3f" % time}&quality=#{quality}").body
+    end
+
+    # Events
+
+    def events(since: nil)
+      path = "/events"
+      path = "/events?since=#{since}" if since
+      get(path)
+    end
+
+    def dashboard_url
+      "#{@base_url}/dashboard"
     end
 
     # Sessions
@@ -165,6 +204,109 @@ module Recorder
       end
 
       raise Error, "Composition not ready after #{timeout}s"
+    end
+
+    # Director — Mouse
+
+    def mouse_move(x:, y:, duration: nil, target_width: nil)
+      body = { x: x, y: y }
+      body[:duration] = duration if duration
+      body[:target_width] = target_width if target_width
+      post("/director/mouse/move", body)
+    end
+
+    def mouse_click(x: nil, y: nil, button: 1, duration: nil)
+      body = { button: button }
+      body[:x] = x if x
+      body[:y] = y if y
+      body[:duration] = duration if duration
+      post("/director/mouse/click", body)
+    end
+
+    def mouse_double_click(x: nil, y: nil)
+      body = {}
+      body[:x] = x if x
+      body[:y] = y if y
+      post("/director/mouse/double-click", body)
+    end
+
+    def mouse_right_click(x: nil, y: nil)
+      body = {}
+      body[:x] = x if x
+      body[:y] = y if y
+      post("/director/mouse/right-click", body)
+    end
+
+    def mouse_drag(start_x:, start_y:, end_x:, end_y:, button: 1, duration: nil)
+      body = { start_x: start_x, start_y: start_y, end_x: end_x, end_y: end_y, button: button }
+      body[:duration] = duration if duration
+      post("/director/mouse/drag", body)
+    end
+
+    def mouse_scroll(clicks:, x: nil, y: nil)
+      body = { clicks: clicks }
+      body[:x] = x if x
+      body[:y] = y if y
+      post("/director/mouse/scroll", body)
+    end
+
+    def mouse_position
+      get("/director/mouse/position")
+    end
+
+    # Director — Keyboard
+
+    def keyboard_type(text:, wpm: nil)
+      body = { text: text }
+      body[:wpm] = wpm if wpm
+      post("/director/keyboard/type", body)
+    end
+
+    def keyboard_press(*keys)
+      post("/director/keyboard/press", keys: keys)
+    end
+
+    def keyboard_hold(key:)
+      post("/director/keyboard/hold", key: key)
+    end
+
+    def keyboard_release(key:)
+      post("/director/keyboard/release", key: key)
+    end
+
+    # Director — Window
+
+    def window_find(name: nil, class_name: nil, timeout: 10.0)
+      body = { timeout: timeout }
+      body[:name] = name if name
+      body[:class] = class_name if class_name
+      post("/director/window/find", body)
+    end
+
+    def window_focus(window_id:)
+      post("/director/window/#{encode(window_id)}/focus")
+    end
+
+    def window_move(window_id:, x:, y:)
+      post("/director/window/#{encode(window_id)}/move", x: x, y: y)
+    end
+
+    def window_resize(window_id:, width:, height:)
+      post("/director/window/#{encode(window_id)}/resize", width: width, height: height)
+    end
+
+    def window_minimize(window_id:)
+      post("/director/window/#{encode(window_id)}/minimize")
+    end
+
+    def window_geometry(window_id:)
+      get("/director/window/#{encode(window_id)}/geometry")
+    end
+
+    def window_tile(window_ids:, layout: "side-by-side", bounds: nil)
+      body = { window_ids: window_ids, layout: layout }
+      body[:bounds] = bounds if bounds
+      post("/director/window/tile", body)
     end
 
     # Layout / Utility


### PR DESCRIPTION
## Summary

- All 5 SDKs (Go, Python, Node/TS, Ruby, Java) now implement the full API surface matching the reference Python client
- **30+ methods added per SDK**: display screenshots/streaming, annotations, events, recording screenshots, and all 17 Director endpoints (mouse, keyboard, window)
- **Bug fix**: `CreateCompositionAndWait` now handles 202 Accepted (fixes #24)
- Minor gaps filled: `delete_composition` added to Python/Ruby SDKs, `validate_layout`/`testcard` added to Python SDK

### Methods added to all SDKs

| Category | Methods |
|---|---|
| Display | `display_screenshot`, `display_stream_url`, `display_viewer_url` |
| Annotations | `add_annotation`, `list_annotations` |
| Events | `events` (with since filter), `dashboard_url` |
| Recording screenshots | `recording_screenshot` |
| Director - Mouse | `mouse_move`, `mouse_click`, `mouse_double_click`, `mouse_right_click`, `mouse_drag`, `mouse_scroll`, `mouse_position` |
| Director - Keyboard | `keyboard_type`, `keyboard_press`, `keyboard_hold`, `keyboard_release` |
| Director - Window | `window_find`, `window_focus`, `window_move`, `window_resize`, `window_minimize`, `window_geometry`, `window_tile` |

Fixes #24

## Test plan

- [x] Go: 62 tests pass (including new 202 Accepted test)
- [x] Python SDK: 34 tests pass
- [x] Node/TS: compiles cleanly (`tsc --noEmit`)
- [x] Ruby: syntax OK
- [x] Java: follows existing patterns (no local JDK to compile, CI will verify)
- [x] Core Python: 561 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)