### PR TITLE
feat: add window_class and fill_viewport to launch_app()

### DIFF
--- a/src/thea/recorder.py
+++ b/src/thea/recorder.py
@@ -186,7 +186,15 @@ class Recorder:
 
     # -- Application launching ---------------------------------------------
 
-    def launch_app(self, cmd: list[str], *, env: dict = None, **kwargs) -> subprocess.Popen:
+    def launch_app(
+        self,
+        cmd: list[str],
+        *,
+        env: dict = None,
+        window_class: str = None,
+        fill_viewport: bool = False,
+        **kwargs,
+    ) -> subprocess.Popen:
         """Launch an application on the recorder's Xvfb display.
 
         The process is tracked and will be terminated automatically when
@@ -201,6 +209,12 @@ class Recorder:
             cmd: Command and arguments, e.g. ``["chromium", "--no-sandbox"]``.
             env: Extra environment variables.  These are merged on top of
                 :attr:`display_env`.  If *None*, only ``DISPLAY`` is added.
+            window_class: WM_CLASS to search for after launch.  Used together
+                with *fill_viewport* to automatically position and resize the
+                window.
+            fill_viewport: If *True* and *window_class* is provided, the
+                launched window is found by class, focused, moved to (0, 0),
+                and resized to fill the display viewport.
             **kwargs: Passed through to :class:`subprocess.Popen`.
 
         Returns:
@@ -212,6 +226,13 @@ class Recorder:
         proc = subprocess.Popen(cmd, env=merged_env, **kwargs)
         self._launched_apps.append(proc)
         logger.debug("Launched app (pid %d): %s", proc.pid, cmd)
+
+        if window_class and fill_viewport:
+            w, h = self._display_size.split("x")
+            win = self.director.window_by_class(window_class)
+            win.focus().move(0, 0).resize(int(w), int(h))
+            time.sleep(0.3)
+
         return proc
 
     # -- Panels ------------------------------------------------------------

--- a/tests/test_recorder_launch.py
+++ b/tests/test_recorder_launch.py
@@ -1,0 +1,57 @@
+"""Tests for launch_app fill_viewport feature."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from thea.recorder import Recorder
+
+
+@pytest.fixture
+def rec(tmp_path):
+    r = Recorder(output_dir=str(tmp_path), display=99, display_size="1280x720")
+    return r
+
+
+class TestLaunchAppFillViewport:
+    def test_basic_launch_unchanged(self, rec):
+        """launch_app without new params works as before."""
+        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=123)
+            proc = rec.launch_app(["xterm"])
+            mock_popen.assert_called_once()
+            assert proc.pid == 123
+
+    def test_fill_viewport_finds_and_resizes(self, rec):
+        """fill_viewport=True uses Director to find and resize window."""
+        mock_win = MagicMock()
+        mock_win.focus.return_value = mock_win
+        mock_win.move.return_value = mock_win
+        mock_win.resize.return_value = mock_win
+
+        mock_director = MagicMock()
+        mock_director.window_by_class.return_value = mock_win
+        rec._director = mock_director
+
+        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=123)
+            with patch("thea.recorder.time.sleep"):
+                rec.launch_app(["xterm"], window_class="XTerm", fill_viewport=True)
+
+        mock_director.window_by_class.assert_called_once_with("XTerm")
+        mock_win.focus.assert_called_once()
+        mock_win.move.assert_called_once_with(0, 0)
+        mock_win.resize.assert_called_once_with(1280, 720)
+
+    def test_window_class_without_fill_viewport_no_resize(self, rec):
+        """window_class alone doesn't trigger resize."""
+        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=123)
+            rec.launch_app(["xterm"], window_class="XTerm")
+        # Director should not be accessed at all
+        assert rec._director is None
+
+    def test_fill_viewport_without_window_class_no_resize(self, rec):
+        """fill_viewport without window_class is a no-op."""
+        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=123)
+            rec.launch_app(["xterm"], fill_viewport=True)
+        assert rec._director is None


### PR DESCRIPTION
## Summary
- Adds `window_class` and `fill_viewport` keyword arguments to `Recorder.launch_app()`
- When both are provided, the Director automatically finds the window by WM_CLASS, focuses it, moves it to (0, 0), and resizes it to fill the display viewport
- Eliminates the repetitive 3-step pattern users currently do after every `launch_app()` call

## Test plan
- [x] New tests in `tests/test_recorder_launch.py` (4 tests, all passing)
- [x] Basic launch without new params works unchanged
- [x] `fill_viewport=True` with `window_class` triggers find + focus + move + resize
- [x] `window_class` alone does not trigger resize
- [x] `fill_viewport=True` alone does not trigger resize

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)