### PR TITLE
feat: library-mode parity for keyboard, mouse, and annotations

### DIFF
--- a/src/thea/recorder.py
+++ b/src/thea/recorder.py
@@ -105,6 +105,8 @@ class Recorder:
         self._panels = {}  # name -> {"title": str, "path": str, "width": int|None, "height": int|None, "bg_color": str, "opacity": float}
         self._launched_apps = []  # Popen instances launched via launch_app()
         self._director = None  # Lazy-initialised Director instance
+        self._annotations = []
+        self._last_annotations = []
 
     # -- Display -----------------------------------------------------------
 
@@ -183,6 +185,57 @@ class Recorder:
             from .director import Director
             self._director = Director(self.display_env)
         return self._director
+
+    # -- Input convenience (delegates to Director) -------------------------
+
+    def keyboard_type(self, text: str, *, wpm: float = None):
+        """Type text with human-like rhythm. Delegates to the Director's keyboard."""
+        self.director.keyboard.type(text, wpm=wpm)
+
+    def keyboard_press(self, *keys: str):
+        """Press one or more keys. Delegates to the Director's keyboard."""
+        self.director.keyboard.press(*keys)
+
+    def mouse_move(self, x: int, y: int, *, duration: float = None):
+        """Move the mouse with human-like motion. Delegates to the Director's mouse."""
+        self.director.mouse.move(x, y, duration=duration)
+
+    def mouse_click(self, x: int, y: int = None, *, button: int = 1):
+        """Click at a position. Delegates to the Director's mouse."""
+        if y is not None:
+            self.director.mouse.click(x, y, button=button)
+        else:
+            self.director.mouse.click(x, button=button)
+
+    # -- Annotations -------------------------------------------------------
+
+    def add_annotation(self, label: str, *, time: float = None, details: str = None) -> dict:
+        """Add an annotation to the current recording.
+
+        Args:
+            label: Short label for the annotation.
+            time: Time offset in seconds. *None* uses recording_elapsed.
+            details: Optional longer description.
+
+        Returns:
+            The annotation dict.
+
+        Raises:
+            RuntimeError: If not currently recording.
+        """
+        if self._ffmpeg_proc is None:
+            raise RuntimeError("Not recording")
+        if time is None:
+            time = round(self.recording_elapsed, 3)
+        annotation = {"label": label, "time": round(time, 3)}
+        if details is not None:
+            annotation["details"] = details
+        self._annotations.append(annotation)
+        return annotation
+
+    def list_annotations(self) -> list[dict]:
+        """Return annotations for the current recording."""
+        return list(self._annotations)
 
     # -- Application launching ---------------------------------------------
 
@@ -422,6 +475,7 @@ class Recorder:
         warnings = self.validate_layout()
         os.makedirs(self._output_dir, exist_ok=True)
         self._recording_start = time.monotonic()
+        self._annotations = []
 
         safe = re.sub(r"[^\w\-.]", "_", filename)[:120]
         self._output_path = os.path.join(self._output_dir, f"{safe}.mp4")
@@ -663,6 +717,7 @@ class Recorder:
             )
 
         path = self._output_path
+        self._last_annotations = list(self._annotations)
         self._ffmpeg_proc = None
         self._output_path = None
         self._recording_start = None

--- a/tests/test_recorder_parity.py
+++ b/tests/test_recorder_parity.py
@@ -1,0 +1,95 @@
+"""Tests for library-mode parity: keyboard, mouse, and annotations on Recorder."""
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from thea.recorder import Recorder
+
+
+@pytest.fixture
+def rec(tmp_path):
+    r = Recorder(output_dir=str(tmp_path), display=99)
+    return r
+
+
+class TestKeyboardConvenience:
+    def test_keyboard_type_delegates(self, rec):
+        mock_director = MagicMock()
+        rec._director = mock_director
+        rec.keyboard_type("hello", wpm=200)
+        mock_director.keyboard.type.assert_called_once_with("hello", wpm=200)
+
+    def test_keyboard_press_delegates(self, rec):
+        mock_director = MagicMock()
+        rec._director = mock_director
+        rec.keyboard_press("Return")
+        mock_director.keyboard.press.assert_called_once_with("Return")
+
+    def test_keyboard_press_multiple_keys(self, rec):
+        mock_director = MagicMock()
+        rec._director = mock_director
+        rec.keyboard_press("ctrl+l")
+        mock_director.keyboard.press.assert_called_once_with("ctrl+l")
+
+
+class TestMouseConvenience:
+    def test_mouse_move_delegates(self, rec):
+        mock_director = MagicMock()
+        rec._director = mock_director
+        rec.mouse_move(100, 200, duration=0.5)
+        mock_director.mouse.move.assert_called_once_with(100, 200, duration=0.5)
+
+    def test_mouse_click_delegates(self, rec):
+        mock_director = MagicMock()
+        rec._director = mock_director
+        rec.mouse_click(100, 200, button=1)
+        mock_director.mouse.click.assert_called_once_with(100, 200, button=1)
+
+
+class TestAnnotations:
+    def test_add_annotation_requires_recording(self, rec):
+        with pytest.raises(RuntimeError, match="Not recording"):
+            rec.add_annotation("test")
+
+    def test_add_annotation_auto_time(self, rec):
+        rec._ffmpeg_proc = MagicMock()
+        rec._recording_start = 100.0
+        with patch("thea.recorder.time") as mock_time:
+            mock_time.monotonic.return_value = 105.5
+            ann = rec.add_annotation("step1")
+        assert ann["label"] == "step1"
+        assert ann["time"] == 5.5
+        assert "details" not in ann
+
+    def test_add_annotation_explicit_time(self, rec):
+        rec._ffmpeg_proc = MagicMock()
+        rec._recording_start = 100.0
+        ann = rec.add_annotation("step1", time=3.0)
+        assert ann["time"] == 3.0
+
+    def test_add_annotation_with_details(self, rec):
+        rec._ffmpeg_proc = MagicMock()
+        rec._recording_start = 100.0
+        ann = rec.add_annotation("step1", time=1.0, details="did a thing")
+        assert ann["details"] == "did a thing"
+
+    def test_list_annotations(self, rec):
+        rec._ffmpeg_proc = MagicMock()
+        rec._recording_start = 100.0
+        rec.add_annotation("a", time=1.0)
+        rec.add_annotation("b", time=2.0)
+        anns = rec.list_annotations()
+        assert len(anns) == 2
+        assert anns[0]["label"] == "a"
+        assert anns[1]["label"] == "b"
+
+    def test_annotations_reset_on_start_recording(self, rec, tmp_path):
+        rec._ffmpeg_proc = MagicMock()
+        rec._recording_start = 100.0
+        rec.add_annotation("old", time=1.0)
+        assert len(rec._annotations) == 1
+        # Simulate start_recording resetting annotations
+        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            with patch("thea.recorder.os.makedirs"):
+                rec.start_recording("test")
+        assert len(rec._annotations) == 0


### PR DESCRIPTION
## Summary
- Add `keyboard_type`, `keyboard_press`, `mouse_move`, and `mouse_click` convenience methods to `Recorder` that delegate to the Director
- Add `add_annotation` and `list_annotations` methods for recording annotations directly on the Recorder (previously only available via the HTTP server)
- Annotations auto-reset on `start_recording()` and are preserved as `_last_annotations` on `stop_recording()`

Closes #26

## Test plan
- [x] 11 new tests in `tests/test_recorder_parity.py` covering all new methods
- [x] All 572 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)