### PR TITLE
feat: add step tracker for generate_report timelines

### DIFF
--- a/src/thea/recorder.py
+++ b/src/thea/recorder.py
@@ -19,6 +19,7 @@ import re
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 
 from .layout import Region, generate_testcard, validate_regions
 
@@ -107,6 +108,8 @@ class Recorder:
         self._director = None  # Lazy-initialised Director instance
         self._annotations = []
         self._last_annotations = []
+        self._steps = []               # Steps for current recording
+        self._last_recording_steps = [] # Steps from last completed recording
 
     # -- Display -----------------------------------------------------------
 
@@ -236,6 +239,57 @@ class Recorder:
     def list_annotations(self) -> list[dict]:
         """Return annotations for the current recording."""
         return list(self._annotations)
+
+    # -- Step tracking -----------------------------------------------------
+
+    @contextmanager
+    def step(self, name: str, *, keyword: str = "Step"):
+        """Track a step for generate_report timelines.
+
+        Usage::
+
+            with rec.step("Register a domain"):
+                run_command("dm domains add example.com")
+
+        On clean exit the step is marked ``"passed"``.  If the block
+        raises, the step is marked ``"failed"`` and the exception
+        propagates.
+
+        Args:
+            name: Human-readable step description.
+            keyword: Step keyword (default ``"Step"``).
+        """
+        entry = {
+            "keyword": keyword,
+            "name": name,
+            "status": "running",
+            "offset": self.recording_elapsed,
+        }
+        self._steps.append(entry)
+        try:
+            yield entry
+            entry["status"] = "passed"
+        except Exception:
+            entry["status"] = "failed"
+            raise
+
+    @property
+    def last_recording_steps(self) -> list[dict]:
+        """Steps collected during the last completed recording."""
+        return list(self._last_recording_steps)
+
+    @property
+    def last_recording_status(self) -> str:
+        """Overall status of the last completed recording.
+
+        Returns ``"passed"`` if all steps passed (or there were no steps),
+        ``"failed"`` if any step failed.
+        """
+        if not self._last_recording_steps:
+            return "passed"
+        if any(s["status"] == "failed" for s in self._last_recording_steps):
+            return "failed"
+        return "passed"
 
     # -- Application launching ---------------------------------------------
 
@@ -497,6 +551,7 @@ class Recorder:
         os.makedirs(self._output_dir, exist_ok=True)
         self._recording_start = time.monotonic()
         self._annotations = []
+        self._steps = []
 
         safe = re.sub(r"[^\w\-.]", "_", filename)[:120]
         self._output_path = os.path.join(self._output_dir, f"{safe}.mp4")
@@ -739,6 +794,7 @@ class Recorder:
 
         path = self._output_path
         self._last_annotations = list(self._annotations)
+        self._last_recording_steps = list(self._steps)
         self._ffmpeg_proc = None
         self._output_path = None
         self._recording_start = None

--- a/tests/test_recorder_steps.py
+++ b/tests/test_recorder_steps.py
@@ -1,0 +1,110 @@
+"""Tests for step tracker context manager."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from thea.recorder import Recorder
+
+
+@pytest.fixture
+def rec(tmp_path):
+    r = Recorder(output_dir=str(tmp_path), display=99)
+    return r
+
+
+class TestStepTracker:
+    def test_step_passed(self, rec):
+        rec._recording_start = 100.0
+        with patch("thea.recorder.time") as mock_time:
+            mock_time.monotonic.return_value = 105.0
+            with rec.step("Do something"):
+                pass
+        assert len(rec._steps) == 1
+        assert rec._steps[0]["name"] == "Do something"
+        assert rec._steps[0]["status"] == "passed"
+        assert rec._steps[0]["keyword"] == "Step"
+        assert rec._steps[0]["offset"] == 5.0
+
+    def test_step_failed(self, rec):
+        rec._recording_start = 100.0
+        with patch("thea.recorder.time") as mock_time:
+            mock_time.monotonic.return_value = 105.0
+            with pytest.raises(ValueError):
+                with rec.step("Fail step"):
+                    raise ValueError("boom")
+        assert rec._steps[0]["status"] == "failed"
+
+    def test_step_custom_keyword(self, rec):
+        rec._recording_start = 100.0
+        with patch("thea.recorder.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            with rec.step("Given something", keyword="Given"):
+                pass
+        assert rec._steps[0]["keyword"] == "Given"
+
+    def test_multiple_steps(self, rec):
+        rec._recording_start = 100.0
+        times = iter([101.0, 102.0, 103.0])
+        with patch("thea.recorder.time") as mock_time:
+            mock_time.monotonic.side_effect = lambda: next(times)
+            with rec.step("Step 1"):
+                pass
+            with rec.step("Step 2"):
+                pass
+            with rec.step("Step 3"):
+                pass
+        assert len(rec._steps) == 3
+        assert [s["offset"] for s in rec._steps] == [1.0, 2.0, 3.0]
+
+    def test_steps_reset_on_start_recording(self, rec):
+        rec._recording_start = 100.0
+        with patch("thea.recorder.time") as mock_time:
+            mock_time.monotonic.return_value = 101.0
+            with rec.step("Old step"):
+                pass
+        assert len(rec._steps) == 1
+        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            with patch("thea.recorder.os.makedirs"):
+                rec.start_recording("test")
+        assert len(rec._steps) == 0
+
+    def test_last_recording_steps_preserved(self, rec):
+        rec._ffmpeg_proc = MagicMock()
+        rec._recording_start = 100.0
+        with patch("thea.recorder.time") as mock_time:
+            mock_time.monotonic.return_value = 101.0
+            with rec.step("A step"):
+                pass
+        # Simulate stop_recording
+        rec._ffmpeg_proc.stdin = MagicMock()
+        rec._ffmpeg_proc.stderr = MagicMock()
+        rec._ffmpeg_proc.stderr.read.return_value = b""
+        rec._ffmpeg_proc.returncode = 0
+        rec._output_path = "/tmp/test.mp4"
+        rec.stop_recording()
+        assert len(rec.last_recording_steps) == 1
+        assert rec.last_recording_steps[0]["name"] == "A step"
+
+    def test_last_recording_status_passed(self, rec):
+        rec._last_recording_steps = [
+            {"keyword": "Step", "name": "a", "status": "passed", "offset": 0},
+            {"keyword": "Step", "name": "b", "status": "passed", "offset": 1},
+        ]
+        assert rec.last_recording_status == "passed"
+
+    def test_last_recording_status_failed(self, rec):
+        rec._last_recording_steps = [
+            {"keyword": "Step", "name": "a", "status": "passed", "offset": 0},
+            {"keyword": "Step", "name": "b", "status": "failed", "offset": 1},
+        ]
+        assert rec.last_recording_status == "failed"
+
+    def test_last_recording_status_no_steps(self, rec):
+        assert rec.last_recording_status == "passed"
+
+    def test_step_not_recording(self, rec):
+        """Steps work even without an active recording (offset will be 0.0)."""
+        with rec.step("No recording"):
+            pass
+        assert rec._steps[0]["offset"] == 0.0
+        assert rec._steps[0]["status"] == "passed"


### PR DESCRIPTION
## Summary
- Add `step()` context manager to `Recorder` that tracks step timing (offset from recording start) and pass/fail status
- Add `last_recording_steps` and `last_recording_status` properties for accessing step data after a recording completes
- Steps are automatically reset when a new recording starts and preserved when a recording stops

## Test plan
- [x] 10 new tests in `tests/test_recorder_steps.py` covering:
  - Step pass/fail status tracking
  - Custom keyword support
  - Multiple steps with correct offsets
  - Steps reset on `start_recording()`
  - Steps preserved on `stop_recording()`
  - `last_recording_status` aggregation logic
  - Steps without an active recording (offset defaults to 0.0)
- [x] All 102 existing recorder tests still pass

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)