### PR TITLE
feat: add terminal recording submodule

### DIFF
--- a/src/thea/__init__.py
+++ b/src/thea/__init__.py
@@ -7,6 +7,9 @@ from .layout import Region, validate_regions, generate_testcard
 # Director
 from .director import Director, MotionConfig, RhythmConfig
 
+# Terminal
+from .terminal import Terminal
+
 # Recorder & server components
 from .recorder import Recorder, PANEL_HEIGHT, LINE_HEIGHT
 from .report import generate_report
@@ -19,6 +22,8 @@ __all__ = [
     "Region", "validate_regions", "generate_testcard",
     # Director
     "Director", "MotionConfig", "RhythmConfig",
+    # Terminal
+    "Terminal",
     # Recorder & server
     "Recorder", "PANEL_HEIGHT", "LINE_HEIGHT",
     "generate_report",

--- a/src/thea/terminal/__init__.py
+++ b/src/thea/terminal/__init__.py
@@ -1,0 +1,3 @@
+from .terminal import Terminal
+
+__all__ = ["Terminal"]

--- a/src/thea/terminal/terminal.py
+++ b/src/thea/terminal/terminal.py
@@ -1,0 +1,250 @@
+"""Terminal recording convenience layer.
+
+Wraps xterm launch, window management, and command execution into
+a simple API for recording CLI demos and test runs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import time
+
+
+# ANSI escape code stripping
+_ANSI_RE = re.compile(
+    r'\x1b\[[0-9;]*[a-zA-Z]'    # CSI sequences (colors, cursor)
+    r'|\x1b\][^\x07]*\x07'       # OSC sequences
+    r'|\x1b[()][A-Z0-9]'         # Character set selection
+    r'|\x1b\[\?[0-9;]*[hl]'      # Private mode set/reset
+    r'|\r'                         # Carriage returns
+)
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return _ANSI_RE.sub('', text)
+
+
+class Terminal:
+    """High-level terminal recording interface.
+
+    Launches an xterm on the recorder's display, optionally sets up
+    output capture, and provides convenience methods for typing
+    commands and interacting with the terminal.
+
+    Args:
+        recorder: A :class:`thea.Recorder` instance.
+        font: Font family name (default ``"DejaVu Sans Mono"``).
+        font_size: Font size in points (default ``14``).
+        bg: Background colour as hex (default ``"#000000"``).
+        fg: Foreground colour as hex (default ``"#c0c0c0"``).
+        scrollbar: Show scrollbar (default ``False``).
+        border: Internal border in pixels (default ``8``).
+        shell: Shell to run (default ``"bash"``).
+        capture_output: Set up tee-based output capture for
+            :meth:`latest_output` (default ``True``).
+        prompt_pattern: Regex pattern matching the shell prompt,
+            used by ``wait_for_prompt`` in :meth:`run_command`.
+            If *None*, prompt detection is not available.
+        wpm: Words-per-minute for typing (default ``None`` — uses
+            the Director's default).
+        fill_viewport: Resize xterm to fill the display (default ``True``).
+        env: Extra environment variables for the xterm process.
+
+    Example::
+
+        from thea import Recorder
+        from thea.terminal import Terminal
+
+        rec = Recorder(output_dir="./recordings", display=99)
+        rec.start_display()
+        rec.start_recording("demo")
+
+        term = Terminal(rec, font="JetBrains Mono", font_size=18)
+        term.run_command("echo hello")
+        term.clear()
+        term.close()
+
+        rec.stop_recording()
+    """
+
+    def __init__(
+        self,
+        recorder,
+        *,
+        font: str = "DejaVu Sans Mono",
+        font_size: int = 14,
+        bg: str = "#000000",
+        fg: str = "#c0c0c0",
+        scrollbar: bool = False,
+        border: int = 8,
+        shell: str = "bash",
+        capture_output: bool = True,
+        prompt_pattern: str | None = None,
+        wpm: float | None = None,
+        fill_viewport: bool = True,
+        env: dict | None = None,
+    ):
+        self._rec = recorder
+        self._wpm = wpm
+        self._prompt_pattern = re.compile(prompt_pattern) if prompt_pattern else None
+        self._capture_output = capture_output
+
+        # Output capture state
+        self._stdout_log = None
+        self._stderr_log = None
+        self._stdout_offset = 0
+        self._stderr_offset = 0
+
+        if capture_output:
+            self._stdout_log = tempfile.mktemp(suffix="-stdout.log")
+            self._stderr_log = tempfile.mktemp(suffix="-stderr.log")
+            # Create empty log files
+            for path in (self._stdout_log, self._stderr_log):
+                with open(path, "w") as f:
+                    pass
+
+        # Build xterm command
+        cmd = ["xterm"]
+        cmd.extend(["-fa", font])
+        cmd.extend(["-fs", str(font_size)])
+        cmd.extend(["-bg", bg])
+        cmd.extend(["-fg", fg])
+        cmd.extend(["-b", str(border)])
+        if not scrollbar:
+            cmd.append("+sb")
+        cmd.extend(["-e", shell, "--login"])
+
+        # Launch xterm
+        self._proc = recorder.launch_app(
+            cmd,
+            env=env,
+            window_class="XTerm",
+            fill_viewport=fill_viewport,
+        )
+
+        # Set up output capture if enabled
+        if capture_output and self._stdout_log and self._stderr_log:
+            self._setup_capture()
+
+    def _setup_capture(self):
+        """Set up tee-based output capture in the shell."""
+        # Type the tee setup command quickly (not meant to be seen)
+        tee_cmd = (
+            f"exec > >(tee -a {self._stdout_log}) "
+            f"2> >(tee -a {self._stderr_log} >&2)"
+        )
+        self._rec.director.keyboard.type(tee_cmd, wpm=9999)
+        self._rec.director.keyboard.press("Return")
+        time.sleep(0.3)
+        # Clear screen so the plumbing isn't visible
+        self._rec.director.keyboard.press("ctrl+l")
+        time.sleep(0.3)
+        # Mark initial offset
+        self._mark_offset()
+
+    def _mark_offset(self):
+        """Record current log file sizes for latest_output tracking."""
+        if self._stdout_log and os.path.exists(self._stdout_log):
+            self._stdout_offset = os.path.getsize(self._stdout_log)
+        if self._stderr_log and os.path.exists(self._stderr_log):
+            self._stderr_offset = os.path.getsize(self._stderr_log)
+
+    def _read_from(self, path: str, offset: int) -> str:
+        """Read new content from a log file starting at offset."""
+        if not path or not os.path.exists(path):
+            return ""
+        with open(path, "r", errors="replace") as f:
+            f.seek(offset)
+            return f.read()
+
+    def run_command(
+        self,
+        command: str,
+        *,
+        pause_after: float = 1.5,
+        wait_for_prompt: bool = False,
+        timeout: float = 30.0,
+    ):
+        """Type a command, press Enter, and wait.
+
+        Args:
+            command: The command text to type.
+            pause_after: Seconds to wait after pressing Enter
+                (used when ``wait_for_prompt`` is *False*).
+            wait_for_prompt: If *True*, wait for the shell prompt
+                to reappear instead of using a fixed delay.
+                Requires ``prompt_pattern`` to have been set.
+            timeout: Maximum seconds to wait when using prompt
+                detection (default ``30``).
+        """
+        self._mark_offset()
+        kwargs = {}
+        if self._wpm is not None:
+            kwargs["wpm"] = self._wpm
+        self._rec.keyboard_type(command, **kwargs)
+        self._rec.keyboard_press("Return")
+
+        if wait_for_prompt and self._prompt_pattern:
+            self._wait_for_prompt(timeout)
+        else:
+            time.sleep(pause_after)
+
+    def _wait_for_prompt(self, timeout: float):
+        """Poll log output for the prompt pattern."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            output = self._read_from(self._stdout_log, self._stdout_offset)
+            clean = _strip_ansi(output)
+            # Check if prompt appears in the output (after the command itself)
+            lines = clean.split("\n")
+            if len(lines) >= 2 and self._prompt_pattern.search(lines[-1]):
+                return
+            time.sleep(0.1)
+        # Timeout — continue anyway
+
+    def latest_output(self) -> str:
+        """Return ANSI-stripped output since the last :meth:`run_command`.
+
+        Returns:
+            Combined stdout and stderr text with ANSI codes removed.
+        """
+        if not self._capture_output:
+            return ""
+        stdout = self._read_from(self._stdout_log, self._stdout_offset)
+        stderr = self._read_from(self._stderr_log, self._stderr_offset)
+        return _strip_ansi(stdout + stderr)
+
+    def latest_stdout(self) -> str:
+        """Return ANSI-stripped stdout since the last :meth:`run_command`."""
+        if not self._capture_output:
+            return ""
+        return _strip_ansi(self._read_from(self._stdout_log, self._stdout_offset))
+
+    def latest_stderr(self) -> str:
+        """Return ANSI-stripped stderr since the last :meth:`run_command`."""
+        if not self._capture_output:
+            return ""
+        return _strip_ansi(self._read_from(self._stderr_log, self._stderr_offset))
+
+    def clear(self):
+        """Clear the terminal screen (Ctrl+L)."""
+        self._rec.keyboard_press("ctrl+l")
+        time.sleep(0.3)
+
+    def close(self):
+        """Exit the terminal session cleanly."""
+        self._rec.keyboard_type("exit")
+        self._rec.keyboard_press("Return")
+        time.sleep(0.5)
+
+    def cleanup(self):
+        """Remove temporary log files."""
+        for path in (self._stdout_log, self._stderr_log):
+            if path:
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,316 @@
+"""Tests for thea.terminal module."""
+import os
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from thea.terminal.terminal import Terminal, _strip_ansi
+
+
+class TestStripAnsi:
+    def test_strips_color_codes(self):
+        assert _strip_ansi("\x1b[31mred\x1b[0m") == "red"
+
+    def test_strips_osc_sequences(self):
+        assert _strip_ansi("\x1b]0;title\x07text") == "text"
+
+    def test_strips_carriage_returns(self):
+        assert _strip_ansi("hello\rworld") == "helloworld"
+
+    def test_preserves_plain_text(self):
+        assert _strip_ansi("hello world") == "hello world"
+
+    def test_strips_cursor_sequences(self):
+        assert _strip_ansi("\x1b[?25hvisible") == "visible"
+
+
+class TestTerminalInit:
+    def test_launches_xterm_with_defaults(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            term = Terminal(rec, capture_output=False)
+
+        rec.launch_app.assert_called_once()
+        args, kwargs = rec.launch_app.call_args
+        cmd = args[0]
+        assert cmd[0] == "xterm"
+        assert "-fa" in cmd
+        assert "DejaVu Sans Mono" in cmd
+        assert kwargs["window_class"] == "XTerm"
+        assert kwargs["fill_viewport"] is True
+
+    def test_custom_font_and_colors(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            term = Terminal(
+                rec,
+                font="JetBrains Mono",
+                font_size=18,
+                bg="#1a1a2e",
+                fg="#00ff00",
+                capture_output=False,
+            )
+
+        cmd = rec.launch_app.call_args[0][0]
+        assert "JetBrains Mono" in cmd
+        assert "18" in cmd
+        assert "#1a1a2e" in cmd
+        assert "#00ff00" in cmd
+
+    def test_scrollbar_enabled(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            term = Terminal(rec, scrollbar=True, capture_output=False)
+
+        cmd = rec.launch_app.call_args[0][0]
+        assert "+sb" not in cmd
+
+    def test_capture_output_sets_up_tee(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.tempfile") as mock_tmp:
+                mock_tmp.mktemp.side_effect = ["/tmp/stdout.log", "/tmp/stderr.log"]
+                with patch("builtins.open", MagicMock()):
+                    with patch("thea.terminal.terminal.os.path.exists", return_value=True):
+                        with patch("thea.terminal.terminal.os.path.getsize", return_value=0):
+                            term = Terminal(rec, capture_output=True)
+
+        # Should have typed the tee setup command
+        rec.director.keyboard.type.assert_called()
+        rec.director.keyboard.press.assert_called()
+
+
+class TestRunCommand:
+    def test_types_command_and_presses_enter(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        with patch("thea.terminal.terminal.time") as mock_time:
+            term.run_command("echo hello")
+
+        rec.keyboard_type.assert_called_with("echo hello")
+        rec.keyboard_press.assert_called_with("Return")
+        mock_time.sleep.assert_called_with(1.5)
+
+    def test_custom_pause_after(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        with patch("thea.terminal.terminal.time") as mock_time:
+            term.run_command("slow command", pause_after=5.0)
+
+        mock_time.sleep.assert_called_with(5.0)
+
+    def test_custom_wpm(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False, wpm=200)
+
+        with patch("thea.terminal.terminal.time"):
+            term.run_command("fast typing")
+
+        rec.keyboard_type.assert_called_with("fast typing", wpm=200)
+
+
+class TestClear:
+    def test_sends_ctrl_l(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        with patch("thea.terminal.terminal.time"):
+            term.clear()
+
+        rec.keyboard_press.assert_called_with("ctrl+l")
+
+
+class TestClose:
+    def test_types_exit(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        with patch("thea.terminal.terminal.time"):
+            term.close()
+
+        rec.keyboard_type.assert_called_with("exit")
+
+
+class TestLatestOutput:
+    def test_returns_empty_when_capture_disabled(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        assert term.latest_output() == ""
+
+    def test_reads_from_offset(self, tmp_path):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        stdout_log = str(tmp_path / "stdout.log")
+        stderr_log = str(tmp_path / "stderr.log")
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        # Manually set up capture state
+        term._capture_output = True
+        term._stdout_log = stdout_log
+        term._stderr_log = stderr_log
+
+        # Write some content
+        with open(stdout_log, "w") as f:
+            f.write("old output\nnew output\n")
+        with open(stderr_log, "w") as f:
+            f.write("")
+
+        # Set offset past "old output\n"
+        term._stdout_offset = len("old output\n")
+        term._stderr_offset = 0
+
+        result = term.latest_output()
+        assert result == "new output\n"
+
+    def test_strips_ansi_from_output(self, tmp_path):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        stdout_log = str(tmp_path / "stdout.log")
+        stderr_log = str(tmp_path / "stderr.log")
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        term._capture_output = True
+        term._stdout_log = stdout_log
+        term._stderr_log = stderr_log
+        term._stdout_offset = 0
+        term._stderr_offset = 0
+
+        with open(stdout_log, "w") as f:
+            f.write("\x1b[32mgreen text\x1b[0m\n")
+        with open(stderr_log, "w") as f:
+            f.write("")
+
+        result = term.latest_output()
+        assert result == "green text\n"
+
+
+class TestLatestStdoutStderr:
+    def test_latest_stdout(self, tmp_path):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        stdout_log = str(tmp_path / "stdout.log")
+        stderr_log = str(tmp_path / "stderr.log")
+        term._capture_output = True
+        term._stdout_log = stdout_log
+        term._stderr_log = stderr_log
+        term._stdout_offset = 0
+        term._stderr_offset = 0
+
+        with open(stdout_log, "w") as f:
+            f.write("stdout content\n")
+        with open(stderr_log, "w") as f:
+            f.write("stderr content\n")
+
+        assert term.latest_stdout() == "stdout content\n"
+        assert term.latest_stderr() == "stderr content\n"
+        assert "stdout content" in term.latest_output()
+        assert "stderr content" in term.latest_output()
+
+    def test_returns_empty_when_capture_disabled(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        assert term.latest_stdout() == ""
+        assert term.latest_stderr() == ""
+
+
+class TestCleanup:
+    def test_removes_log_files(self, tmp_path):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        stdout_log = str(tmp_path / "stdout.log")
+        stderr_log = str(tmp_path / "stderr.log")
+        for path in (stdout_log, stderr_log):
+            with open(path, "w") as f:
+                f.write("test")
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        term._stdout_log = stdout_log
+        term._stderr_log = stderr_log
+        term.cleanup()
+
+        assert not os.path.exists(stdout_log)
+        assert not os.path.exists(stderr_log)
+
+    def test_cleanup_missing_files_no_error(self):
+        rec = MagicMock()
+        rec.launch_app.return_value = MagicMock(pid=123)
+        rec.director = MagicMock()
+
+        with patch("thea.terminal.terminal.time"):
+            with patch("thea.terminal.terminal.os.path.exists", return_value=False):
+                term = Terminal(rec, capture_output=False)
+
+        term._stdout_log = "/tmp/nonexistent-stdout.log"
+        term._stderr_log = "/tmp/nonexistent-stderr.log"
+        term.cleanup()  # Should not raise


### PR DESCRIPTION
## Summary
- Adds `thea.terminal` submodule with a `Terminal` class for convenient terminal recording
- Wraps xterm launch, window management, and command execution (run_command, clear, close)
- Includes tee-based output capture with `latest_output()`, `latest_stdout()`, `latest_stderr()` and ANSI stripping
- Follows the same submodule pattern as `thea.director` — no new dependencies
- 21 unit tests covering all public methods

Closes #29

## Test plan
- [x] All 21 new terminal tests pass
- [x] Full test suite (607 tests) passes with no regressions
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)