### PR TITLE
feat: auto-start window manager in start_display()

### DIFF
--- a/src/thea/recorder.py
+++ b/src/thea/recorder.py
@@ -99,6 +99,7 @@ class Recorder:
             self._font_bold = font_bold
 
         self._xvfb_proc = None
+        self._wm_proc = None
         self._ffmpeg_proc = None
         self._output_path = None
         self._recording_start = None
@@ -165,8 +166,48 @@ class Recorder:
         )
         logger.debug("Xvfb started on %s (%sx%s)", self.display_string, w, total_h)
 
+        # Start a window manager so xdotool windowfocus/windowactivate work.
+        self._start_window_manager(env)
+
+    def _start_window_manager(self, env: dict) -> None:
+        """Start openbox and wait for it to be ready.
+
+        Polls for the EWMH ``_NET_SUPPORTING_WM_CHECK`` property which
+        openbox sets once it is ready to manage windows.
+        """
+        self._wm_proc = subprocess.Popen(
+            ["openbox"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Poll until the WM advertises EWMH support.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            result = subprocess.run(
+                ["xprop", "-root", "_NET_SUPPORTING_WM_CHECK"],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            if "window id" in result.stdout.lower():
+                break
+            time.sleep(0.1)
+        logger.debug("Window manager started on %s", self.display_string)
+
+    def _stop_window_manager(self) -> None:
+        """Terminate the window manager if we started one."""
+        if self._wm_proc:
+            self._wm_proc.terminate()
+            try:
+                self._wm_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._wm_proc.kill()
+            self._wm_proc = None
+
     def stop_display(self):
-        """Terminate Xvfb."""
+        """Terminate the window manager and Xvfb."""
+        self._stop_window_manager()
         if self._xvfb_proc:
             self._xvfb_proc.terminate()
             try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,8 @@ def mock_server(tmp_path):
     """Start a real Flask app on a random port for CLI testing."""
     with patch("thea.recorder.subprocess.Popen"), \
          patch("thea.recorder.subprocess.run"), \
-         patch("thea.recorder.os.path.exists", return_value=True):
+         patch("thea.recorder.os.path.exists", return_value=True), \
+         patch("thea.recorder.Recorder._start_window_manager"):
         from thea.server import create_app
         app = create_app(output_dir=str(tmp_path), display=42)
         app.config["TESTING"] = True

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -73,10 +73,11 @@ class TestFonts:
 
 
 class TestStartDisplay:
+    @patch("thea.recorder.Recorder._start_window_manager")
     @patch("thea.recorder.subprocess.run")
     @patch("thea.recorder.os.path.exists", return_value=True)
     @patch("thea.recorder.subprocess.Popen")
-    def test_with_panels_adds_panel_height(self, mock_popen, _exists, _run):
+    def test_with_panels_adds_panel_height(self, mock_popen, _exists, _run, _wm):
         r = Recorder(display=42, display_size="1920x1080")
         r.add_panel("header", title="Header")
         r.start_display()
@@ -88,10 +89,11 @@ class TestStartDisplay:
         assert f"1920x{expected_h}x24" in args
         r.cleanup()
 
+    @patch("thea.recorder.Recorder._start_window_manager")
     @patch("thea.recorder.subprocess.run")
     @patch("thea.recorder.os.path.exists", return_value=True)
     @patch("thea.recorder.subprocess.Popen")
-    def test_without_panels_still_allocates_panel_height(self, mock_popen, _exists, _run):
+    def test_without_panels_still_allocates_panel_height(self, mock_popen, _exists, _run, _wm):
         r = Recorder(display=42, display_size="1920x1080")
         r.start_display()
 
@@ -99,10 +101,11 @@ class TestStartDisplay:
         expected_h = 1080 + PANEL_HEIGHT
         assert f"1920x{expected_h}x24" in args
 
+    @patch("thea.recorder.Recorder._start_window_manager")
     @patch("thea.recorder.subprocess.run")
     @patch("thea.recorder.os.path.exists", return_value=True)
     @patch("thea.recorder.subprocess.Popen")
-    def test_sets_cursor(self, _popen, _exists, mock_run):
+    def test_sets_cursor(self, _popen, _exists, mock_run, _wm):
         r = Recorder(display=42)
         r.start_display()
 
@@ -111,10 +114,11 @@ class TestStartDisplay:
         assert "xsetroot" in args
         assert "-cursor_name" in args
 
+    @patch("thea.recorder.Recorder._start_window_manager")
     @patch("thea.recorder.subprocess.run")
     @patch("thea.recorder.os.path.exists", return_value=True)
     @patch("thea.recorder.subprocess.Popen")
-    def test_stop_display_terminates_xvfb(self, mock_popen, _exists, _run):
+    def test_stop_display_terminates_xvfb(self, mock_popen, _exists, _run, _wm):
         proc = Mock()
         mock_popen.return_value = proc
         r = Recorder()
@@ -128,10 +132,11 @@ class TestStartDisplay:
         r = Recorder()
         r.stop_display()  # Should not raise
 
+    @patch("thea.recorder.Recorder._start_window_manager")
     @patch("thea.recorder.subprocess.run")
     @patch("thea.recorder.os.path.exists", return_value=True)
     @patch("thea.recorder.subprocess.Popen")
-    def test_custom_resolution(self, mock_popen, _exists, _run):
+    def test_custom_resolution(self, mock_popen, _exists, _run, _wm):
         r = Recorder(display=1, display_size="1280x720")
         r.start_display()
 
@@ -139,15 +144,124 @@ class TestStartDisplay:
         expected_h = 720 + PANEL_HEIGHT
         assert f"1280x{expected_h}x24" in args
 
+    @patch("thea.recorder.Recorder._start_window_manager")
     @patch("thea.recorder.subprocess.run")
     @patch("thea.recorder.os.path.exists", return_value=True)
     @patch("thea.recorder.subprocess.Popen")
-    def test_display_env_passed_to_xsetroot(self, _popen, _exists, mock_run):
+    def test_display_env_passed_to_xsetroot(self, _popen, _exists, mock_run, _wm):
         r = Recorder(display=77)
         r.start_display()
 
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["env"]["DISPLAY"] == ":77"
+
+    @patch("thea.recorder.Recorder._start_window_manager")
+    @patch("thea.recorder.subprocess.run")
+    @patch("thea.recorder.os.path.exists", return_value=True)
+    @patch("thea.recorder.subprocess.Popen")
+    def test_start_display_calls_start_window_manager(self, _popen, _exists, _run, mock_wm):
+        r = Recorder(display=42)
+        r.start_display()
+
+        mock_wm.assert_called_once()
+        # env dict should have the correct DISPLAY
+        env_arg = mock_wm.call_args[0][0]
+        assert env_arg["DISPLAY"] == ":42"
+
+
+class TestWindowManager:
+    @patch("thea.recorder.time.sleep")
+    @patch("thea.recorder.subprocess.Popen")
+    def test_start_window_manager_starts_openbox(self, mock_popen, _sleep):
+        wm_proc = Mock()
+        mock_popen.return_value = wm_proc
+        run_result = Mock()
+        run_result.stdout = "_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001"
+        with patch("thea.recorder.subprocess.run", return_value=run_result):
+            r = Recorder(display=42)
+            env = r.display_env
+            r._start_window_manager(env)
+
+        # openbox was started
+        popen_args = mock_popen.call_args[0][0]
+        assert popen_args == ["openbox"]
+        assert r._wm_proc is wm_proc
+
+    @patch("thea.recorder.time.sleep")
+    @patch("thea.recorder.subprocess.Popen")
+    def test_start_window_manager_polls_until_ready(self, mock_popen, mock_sleep):
+        mock_popen.return_value = Mock()
+        not_ready = Mock()
+        not_ready.stdout = ""
+        ready = Mock()
+        ready.stdout = "_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001"
+        with patch("thea.recorder.subprocess.run", side_effect=[not_ready, not_ready, ready]):
+            r = Recorder(display=42)
+            r._start_window_manager(r.display_env)
+
+        # Slept between polls
+        assert mock_sleep.call_count == 2
+
+    def test_stop_window_manager_terminates_proc(self):
+        r = Recorder()
+        proc = Mock()
+        proc.poll.return_value = None
+        r._wm_proc = proc
+        r._stop_window_manager()
+
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once()
+        assert r._wm_proc is None
+
+    def test_stop_window_manager_noop_when_none(self):
+        r = Recorder()
+        r._stop_window_manager()  # Should not raise
+
+    def test_stop_window_manager_force_kills_on_timeout(self):
+        r = Recorder()
+        proc = Mock()
+        proc.wait.side_effect = subprocess.TimeoutExpired("openbox", 5)
+        r._wm_proc = proc
+        r._stop_window_manager()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert r._wm_proc is None
+
+    @patch("thea.recorder.Recorder._start_window_manager")
+    @patch("thea.recorder.subprocess.run")
+    @patch("thea.recorder.os.path.exists", return_value=True)
+    @patch("thea.recorder.subprocess.Popen")
+    def test_stop_display_stops_wm_before_xvfb(self, mock_popen, _exists, _run, _wm):
+        xvfb_proc = Mock()
+        mock_popen.return_value = xvfb_proc
+        wm_proc = Mock()
+
+        r = Recorder()
+        r.start_display()
+        r._wm_proc = wm_proc
+
+        r.stop_display()
+
+        wm_proc.terminate.assert_called_once()
+        xvfb_proc.terminate.assert_called_once()
+
+    @patch("thea.recorder.Recorder._start_window_manager")
+    @patch("thea.recorder.subprocess.run")
+    @patch("thea.recorder.os.path.exists", return_value=True)
+    @patch("thea.recorder.subprocess.Popen")
+    def test_cleanup_stops_wm(self, mock_popen, _exists, _run, _wm):
+        xvfb_proc = Mock()
+        mock_popen.return_value = xvfb_proc
+        wm_proc = Mock()
+
+        r = Recorder()
+        r.start_display()
+        r._wm_proc = wm_proc
+
+        r.cleanup()
+
+        wm_proc.terminate.assert_called_once()
 
 
 class TestDisplayEnv:
@@ -674,10 +788,11 @@ class TestRecordingElapsed:
 
 
 class TestCleanup:
+    @patch("thea.recorder.Recorder._start_window_manager")
     @patch("thea.recorder.subprocess.run")
     @patch("thea.recorder.os.path.exists", return_value=True)
     @patch("thea.recorder.subprocess.Popen")
-    def test_cleanup_stops_everything(self, mock_popen, _exists, _run, tmp_path):
+    def test_cleanup_stops_everything(self, mock_popen, _exists, _run, _wm, tmp_path):
         ffmpeg_proc = Mock()
         ffmpeg_proc.returncode = 0
         ffmpeg_proc.stderr = None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,7 +18,8 @@ def app(tmp_path):
     """Create a test app with mocked subprocess calls."""
     with patch("thea.recorder.subprocess.Popen"), \
          patch("thea.recorder.subprocess.run"), \
-         patch("thea.recorder.os.path.exists", return_value=True):
+         patch("thea.recorder.os.path.exists", return_value=True), \
+         patch("thea.recorder.Recorder._start_window_manager"):
         app = create_app(output_dir=str(tmp_path), display=42)
         app.config["TESTING"] = True
         yield app
@@ -33,7 +34,8 @@ def client(app):
 def app_cors(tmp_path):
     with patch("thea.recorder.subprocess.Popen"), \
          patch("thea.recorder.subprocess.run"), \
-         patch("thea.recorder.os.path.exists", return_value=True):
+         patch("thea.recorder.os.path.exists", return_value=True), \
+         patch("thea.recorder.Recorder._start_window_manager"):
         app = create_app(output_dir=str(tmp_path), display=42, enable_cors=True)
         app.config["TESTING"] = True
         yield app

--- a/tests/test_server_annotations.py
+++ b/tests/test_server_annotations.py
@@ -11,7 +11,8 @@ from thea.server import create_app
 def app(tmp_path):
     with patch("thea.recorder.subprocess.Popen"), \
          patch("thea.recorder.subprocess.run"), \
-         patch("thea.recorder.os.path.exists", return_value=True):
+         patch("thea.recorder.os.path.exists", return_value=True), \
+         patch("thea.recorder.Recorder._start_window_manager"):
         app = create_app(output_dir=str(tmp_path), display=42)
         app.config["TESTING"] = True
         yield app
@@ -23,7 +24,8 @@ def client(app):
 
 
 def _start_recording(client, name="demo"):
-    with patch("thea.recorder.subprocess.Popen") as mock_popen:
+    with patch("thea.recorder.subprocess.Popen") as mock_popen, \
+         patch("thea.recorder.Recorder._start_window_manager"):
         mock_proc = Mock()
         mock_proc.poll.return_value = None
         mock_proc.returncode = 0
@@ -170,7 +172,8 @@ class TestSessionAnnotations:
             return client.post("/sessions", json={"name": name})
 
     def _start_session_recording(self, client, session_name, rec_name="demo"):
-        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+        with patch("thea.recorder.subprocess.Popen") as mock_popen, \
+             patch("thea.recorder.Recorder._start_window_manager"):
             mock_proc = Mock()
             mock_proc.poll.return_value = None
             mock_popen.return_value = mock_proc

--- a/tests/test_server_display.py
+++ b/tests/test_server_display.py
@@ -13,7 +13,8 @@ from thea.server import create_app
 def app(tmp_path):
     with patch("thea.recorder.subprocess.Popen"), \
          patch("thea.recorder.subprocess.run"), \
-         patch("thea.recorder.os.path.exists", return_value=True):
+         patch("thea.recorder.os.path.exists", return_value=True), \
+         patch("thea.recorder.Recorder._start_window_manager"):
         app = create_app(output_dir=str(tmp_path), display=42)
         app.config["TESTING"] = True
         yield app
@@ -37,7 +38,8 @@ class TestDisplayScreenshot:
     def test_screenshot_returns_jpeg(self, mock_run, client):
         """Screenshot returns JPEG bytes when display is running."""
         # Start the display first
-        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+        with patch("thea.recorder.subprocess.Popen") as mock_popen, \
+             patch("thea.recorder.Recorder._start_window_manager"):
             mock_proc = Mock()
             mock_proc.poll.return_value = None
             mock_popen.return_value = mock_proc
@@ -58,7 +60,8 @@ class TestDisplayScreenshot:
     @patch("thea.recorder.subprocess.run")
     def test_screenshot_quality_param(self, mock_run, client):
         """Quality parameter is forwarded."""
-        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+        with patch("thea.recorder.subprocess.Popen") as mock_popen, \
+             patch("thea.recorder.Recorder._start_window_manager"):
             mock_proc = Mock()
             mock_proc.poll.return_value = None
             mock_popen.return_value = mock_proc
@@ -80,7 +83,8 @@ class TestDisplayStream:
     @patch("thea.recorder.subprocess.run")
     def test_stream_content_type(self, mock_run, client):
         """Stream returns multipart MJPEG content type."""
-        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+        with patch("thea.recorder.subprocess.Popen") as mock_popen, \
+             patch("thea.recorder.Recorder._start_window_manager"):
             mock_proc = Mock()
             mock_proc.poll.return_value = None
             mock_popen.return_value = mock_proc

--- a/tests/test_server_events.py
+++ b/tests/test_server_events.py
@@ -12,7 +12,8 @@ from thea.server import create_app
 def app(tmp_path):
     with patch("thea.recorder.subprocess.Popen"), \
          patch("thea.recorder.subprocess.run"), \
-         patch("thea.recorder.os.path.exists", return_value=True):
+         patch("thea.recorder.os.path.exists", return_value=True), \
+         patch("thea.recorder.Recorder._start_window_manager"):
         app = create_app(output_dir=str(tmp_path), display=42)
         app.config["TESTING"] = True
         yield app
@@ -30,7 +31,8 @@ class TestEventsEndpoint:
         assert resp.get_json() == []
 
     def test_events_after_display_start(self, client):
-        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+        with patch("thea.recorder.subprocess.Popen") as mock_popen, \
+             patch("thea.recorder.Recorder._start_window_manager"):
             mock_proc = Mock()
             mock_proc.poll.return_value = None
             mock_popen.return_value = mock_proc
@@ -72,7 +74,8 @@ class TestEventsEndpoint:
         assert len(remove_events) == 1
 
     def test_events_after_recording_start_stop(self, client):
-        with patch("thea.recorder.subprocess.Popen") as mock_popen:
+        with patch("thea.recorder.subprocess.Popen") as mock_popen, \
+             patch("thea.recorder.Recorder._start_window_manager"):
             mock_proc = Mock()
             mock_proc.poll.return_value = None
             mock_popen.return_value = mock_proc


### PR DESCRIPTION
## Summary

- `start_display()` now automatically starts openbox and polls for EWMH readiness (`_NET_SUPPORTING_WM_CHECK`) before returning
- `stop_display()` and `cleanup()` terminate the WM alongside Xvfb
- The Director's existing `_ensure_window_manager()` detects the already-running WM and skips starting a duplicate

This eliminates the boilerplate every Thea consumer had to implement (start openbox, wait for readiness, clean up).

Closes #34

## Test plan

- [x] All 594 existing tests pass
- [x] New tests for `_start_window_manager` (starts openbox, polls until ready)
- [x] New tests for `_stop_window_manager` (terminate, force-kill on timeout, no-op when none)
- [x] New tests for WM lifecycle integration (stop_display stops WM before Xvfb, cleanup stops WM)
- [x] Existing start_display tests updated to mock `_start_window_manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)