### PR TITLE
fix: verify WM focus readiness with test window (#36)

### DIFF
--- a/src/thea/director/director.py
+++ b/src/thea/director/director.py
@@ -105,6 +105,59 @@ class Director:
                 break
             time.sleep(0.1)
 
+        # Verify the WM can actually handle focus requests by launching a
+        # throwaway window, focusing it, then killing it.  EWMH properties
+        # appear before openbox is ready to manage focus (#36).
+        self._verify_wm_focus_ready(deadline)
+
+    def _verify_wm_focus_ready(self, deadline: float) -> None:
+        """Launch a test window and verify focus works before returning.
+
+        This catches the race where openbox advertises EWMH properties but
+        cannot yet handle X_SetInputFocus requests (#36).
+        """
+        test_proc = subprocess.Popen(
+            ["xterm", "-geometry", "1x1+0+0", "-e", "sleep 10"],
+            env=self._env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            # Wait for the test window to appear.
+            wid = None
+            while time.monotonic() < deadline:
+                result = subprocess.run(
+                    ["xdotool", "search", "--pid", str(test_proc.pid)],
+                    env=self._env,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    wid = result.stdout.strip().split("\n")[0]
+                    break
+                time.sleep(0.1)
+
+            if wid is None:
+                return  # Could not find test window; skip verification.
+
+            # Try to focus the test window — retry until it works.
+            while time.monotonic() < deadline:
+                result = subprocess.run(
+                    ["xdotool", "windowactivate", "--sync", wid],
+                    env=self._env,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    break
+                time.sleep(0.2)
+        finally:
+            test_proc.terminate()
+            try:
+                test_proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                test_proc.kill()
+
     @property
     def env(self) -> dict:
         """The environment dict with ``DISPLAY`` set."""

--- a/src/thea/director/window.py
+++ b/src/thea/director/window.py
@@ -32,7 +32,7 @@ class Window:
         """The X11 window ID."""
         return self._id
 
-    def focus(self, *, _retries: int = 5) -> Window:
+    def focus(self, *, _retries: int = 10) -> Window:
         """Activate and focus this window (raise to front).
 
         Retries on ``BadMatch`` X errors which can occur when the window

--- a/src/thea/recorder.py
+++ b/src/thea/recorder.py
@@ -208,7 +208,60 @@ class Recorder:
             if "_NET_SUPPORTED" in result.stdout and "no such atom" not in result.stdout.lower():
                 break
             time.sleep(0.1)
+
+        # Verify the WM can actually handle focus requests by launching a
+        # throwaway window, focusing it, then killing it.  EWMH properties
+        # appear before openbox is ready to manage focus (#36).
+        self._verify_wm_focus_ready(env, deadline)
         logger.debug("Window manager started on %s", self.display_string)
+
+    def _verify_wm_focus_ready(self, env: dict, deadline: float) -> None:
+        """Launch a test window and verify focus works before returning.
+
+        This catches the race where openbox advertises EWMH properties but
+        cannot yet handle X_SetInputFocus requests (#36).
+        """
+        test_proc = subprocess.Popen(
+            ["xterm", "-geometry", "1x1+0+0", "-e", "sleep 10"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            # Wait for the test window to appear.
+            wid = None
+            while time.monotonic() < deadline:
+                result = subprocess.run(
+                    ["xdotool", "search", "--pid", str(test_proc.pid)],
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    wid = result.stdout.strip().split("\n")[0]
+                    break
+                time.sleep(0.1)
+
+            if wid is None:
+                return  # Could not find test window; skip verification.
+
+            # Try to focus the test window — retry until it works.
+            while time.monotonic() < deadline:
+                result = subprocess.run(
+                    ["xdotool", "windowactivate", "--sync", wid],
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    break
+                time.sleep(0.2)
+        finally:
+            test_proc.terminate()
+            try:
+                test_proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                test_proc.kill()
 
     def _stop_window_manager(self) -> None:
         """Terminate the window manager if we started one."""

--- a/tests/test_director_director.py
+++ b/tests/test_director_director.py
@@ -13,10 +13,11 @@ from thea.director.rhythm import RhythmConfig
 
 
 class TestDirectorInit:
+    @patch("thea.director.director.Director._verify_wm_focus_ready")
     @patch("thea.director.director.subprocess.run")
     @patch("thea.director.director.subprocess.Popen")
     @patch("thea.director.director.time.sleep")
-    def test_display_string(self, mock_sleep, mock_popen, mock_run):
+    def test_display_string(self, mock_sleep, mock_popen, mock_run, _verify):
         # Simulate no WM running, then WM becomes ready.
         no_wm = MagicMock(stdout="no such atom", returncode=1)
         wm_check = MagicMock(stdout="_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001", returncode=0)
@@ -45,10 +46,11 @@ class TestDirectorInit:
         # Should not start openbox since WM is detected.
         assert d._wm_proc is None
 
+    @patch("thea.director.director.Director._verify_wm_focus_ready")
     @patch("thea.director.director.time.sleep")
     @patch("thea.director.director.subprocess.Popen")
     @patch("thea.director.director.subprocess.run")
-    def test_starts_openbox_when_no_wm(self, mock_run, mock_popen, mock_sleep):
+    def test_starts_openbox_when_no_wm(self, mock_run, mock_popen, mock_sleep, _verify):
         no_wm = MagicMock(stdout="no such atom", returncode=1)
         wm_check = MagicMock(stdout="_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001", returncode=0)
         supported = MagicMock(stdout="_NET_SUPPORTED(ATOM) = _NET_WM_STATE", returncode=0)
@@ -72,6 +74,63 @@ class TestDirectorInit:
         config = RhythmConfig(wpm=120)
         d = Director(":99", rhythm=config)
         assert d.keyboard.rhythm.wpm == 120
+
+
+class TestDirectorWMReadiness:
+    """Regression tests for #36: WM readiness must verify focus actually works."""
+
+    @patch("thea.director.director.time.sleep")
+    @patch("thea.director.director.time.monotonic")
+    @patch("thea.director.director.subprocess.Popen")
+    @patch("thea.director.director.subprocess.run")
+    def test_start_wm_verifies_focus_with_test_window(self, mock_run, mock_popen, mock_mono, mock_sleep):
+        """_ensure_window_manager should create a test window and verify focus works."""
+        no_wm = MagicMock(stdout="no such atom", returncode=1)
+        wm_check = MagicMock(stdout="_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001", returncode=0)
+        supported = MagicMock(stdout="_NET_SUPPORTED(ATOM) = _NET_WM_STATE", returncode=0)
+        # xdotool search returns the test window
+        search_result = MagicMock(stdout="12345\n", returncode=0)
+        # xdotool windowactivate succeeds
+        activate_result = MagicMock(stdout="", returncode=0)
+        # xterm process mock
+        xterm_proc = MagicMock()
+        xterm_proc.poll.return_value = None
+        # openbox process mock
+        openbox_proc = MagicMock()
+        mock_popen.side_effect = [openbox_proc, xterm_proc]
+        mock_run.side_effect = [no_wm, wm_check, supported, search_result, activate_result]
+        mock_mono.side_effect = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        d = Director(":99")
+        # Verify xterm was launched for the focus test
+        assert mock_popen.call_count == 2
+        xterm_call_args = mock_popen.call_args_list[1][0][0]
+        assert "xterm" in xterm_call_args
+        # Verify the test window was cleaned up
+        xterm_proc.terminate.assert_called_once()
+
+    @patch("thea.director.director.time.sleep")
+    @patch("thea.director.director.time.monotonic")
+    @patch("thea.director.director.subprocess.Popen")
+    @patch("thea.director.director.subprocess.run")
+    def test_start_wm_retries_focus_verification(self, mock_run, mock_popen, mock_mono, mock_sleep):
+        """Focus verification should retry if the first activate attempt fails."""
+        no_wm = MagicMock(stdout="no such atom", returncode=1)
+        wm_check = MagicMock(stdout="_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001", returncode=0)
+        supported = MagicMock(stdout="_NET_SUPPORTED(ATOM) = _NET_WM_STATE", returncode=0)
+        # xdotool search: first returns nothing, then finds window
+        search_empty = MagicMock(stdout="", returncode=1)
+        search_found = MagicMock(stdout="12345\n", returncode=0)
+        # xdotool windowactivate: first fails with BadMatch, then succeeds
+        activate_fail = MagicMock(stdout="", returncode=1, stderr="BadMatch")
+        activate_ok = MagicMock(stdout="", returncode=0)
+        xterm_proc = MagicMock()
+        xterm_proc.poll.return_value = None
+        openbox_proc = MagicMock()
+        mock_popen.side_effect = [openbox_proc, xterm_proc]
+        mock_run.side_effect = [no_wm, wm_check, supported, search_empty, search_found, activate_fail, activate_ok]
+        mock_mono.side_effect = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+        d = Director(":99")
+        xterm_proc.terminate.assert_called_once()
 
 
 class TestDirectorProperties:
@@ -136,10 +195,11 @@ class TestDirectorScreenshot:
 
 
 class TestDirectorCleanup:
+    @patch("thea.director.director.Director._verify_wm_focus_ready")
     @patch("thea.director.director.time.sleep")
     @patch("thea.director.director.subprocess.Popen")
     @patch("thea.director.director.subprocess.run")
-    def test_cleanup_terminates_wm(self, mock_run, mock_popen, mock_sleep):
+    def test_cleanup_terminates_wm(self, mock_run, mock_popen, mock_sleep, _verify):
         no_wm = MagicMock(stdout="no such atom", returncode=1)
         wm_check = MagicMock(stdout="_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001", returncode=0)
         supported = MagicMock(stdout="_NET_SUPPORTED(ATOM) = _NET_WM_STATE", returncode=0)
@@ -157,10 +217,11 @@ class TestDirectorCleanup:
         d = Director(":99")
         d.cleanup()  # Should not raise.
 
+    @patch("thea.director.director.Director._verify_wm_focus_ready")
     @patch("thea.director.director.time.sleep")
     @patch("thea.director.director.subprocess.Popen")
     @patch("thea.director.director.subprocess.run")
-    def test_cleanup_force_kill_on_timeout(self, mock_run, mock_popen, mock_sleep):
+    def test_cleanup_force_kill_on_timeout(self, mock_run, mock_popen, mock_sleep, _verify):
         no_wm = MagicMock(stdout="no such atom", returncode=1)
         wm_check = MagicMock(stdout="_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200001", returncode=0)
         supported = MagicMock(stdout="_NET_SUPPORTED(ATOM) = _NET_WM_STATE", returncode=0)

--- a/tests/test_director_window.py
+++ b/tests/test_director_window.py
@@ -93,7 +93,28 @@ class TestWindow:
         w = Window("42", ENV)
         with pytest.raises(RuntimeError, match="BadMatch"):
             w.focus()
-        assert mock_activate.call_count == 5
+        assert mock_activate.call_count == 10
+
+    @patch("thea.director.window.time.sleep")
+    @patch("thea.director.window.xdotool.window_focus")
+    @patch("thea.director.window.xdotool.window_activate")
+    def test_focus_succeeds_after_many_badmatch_retries(self, mock_activate, mock_focus, mock_sleep):
+        """Regression test for #36: 5 retries insufficient when WM is slow to initialise."""
+        # Simulate BadMatch on attempts 1-6, then success on attempt 7.
+        # With the old default of 5 retries, this would raise.
+        mock_activate.side_effect = [
+            RuntimeError("X Error: BadMatch (invalid parameter attributes)"),
+            RuntimeError("X Error: BadMatch (invalid parameter attributes)"),
+            RuntimeError("X Error: BadMatch (invalid parameter attributes)"),
+            RuntimeError("X Error: BadMatch (invalid parameter attributes)"),
+            RuntimeError("X Error: BadMatch (invalid parameter attributes)"),
+            RuntimeError("X Error: BadMatch (invalid parameter attributes)"),
+            None,
+        ]
+        w = Window("42", ENV)
+        result = w.focus()
+        assert result is w
+        assert mock_activate.call_count == 7
 
 
 class TestFindWindow:

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -170,9 +170,10 @@ class TestStartDisplay:
 
 
 class TestWindowManager:
+    @patch("thea.recorder.Recorder._verify_wm_focus_ready")
     @patch("thea.recorder.time.sleep")
     @patch("thea.recorder.subprocess.Popen")
-    def test_start_window_manager_starts_openbox(self, mock_popen, _sleep):
+    def test_start_window_manager_starts_openbox(self, mock_popen, _sleep, _verify):
         wm_proc = Mock()
         mock_popen.return_value = wm_proc
         wm_check = Mock()
@@ -189,9 +190,10 @@ class TestWindowManager:
         assert popen_args == ["openbox"]
         assert r._wm_proc is wm_proc
 
+    @patch("thea.recorder.Recorder._verify_wm_focus_ready")
     @patch("thea.recorder.time.sleep")
     @patch("thea.recorder.subprocess.Popen")
-    def test_start_window_manager_polls_until_ready(self, mock_popen, mock_sleep):
+    def test_start_window_manager_polls_until_ready(self, mock_popen, mock_sleep, _verify):
         mock_popen.return_value = Mock()
         not_ready = Mock()
         not_ready.stdout = ""


### PR DESCRIPTION
## Summary
- After EWMH property checks pass, `_start_window_manager()` now launches a throwaway xterm, verifies `xdotool windowactivate` succeeds on it, then cleans up — proving openbox can actually handle focus requests before returning
- Increased `Window.focus()` default retries from 5 to 10 as a safety net for slow WM initialisation
- Applied to both `Recorder._start_window_manager()` and `Director._ensure_window_manager()`

Fixes #36

## Test plan
- [x] Regression test: 6 consecutive BadMatch errors followed by success (would fail with old 5-retry limit)
- [x] Test: WM startup launches xterm probe and cleans it up
- [x] Test: focus verification retries on failed activate attempts
- [x] Full test suite passes (600 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)