### PR TITLE
Add GIF and WebM output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # thea-recorder
 
-**Record your Xvfb virtual display as MP4 video with live panel overlays and interactive HTML reports.**
+**Record your Xvfb virtual display as MP4, GIF, or WebM video with live panel overlays and interactive HTML reports.**
 
-thea-recorder captures anything running in a virtual display — browser-based E2E tests, GUI applications, desktop automation scripts, product demos — as an MP4 video with a live overlay bar showing status panels, step timelines, and custom context. It then generates an interactive HTML report where you can click any step and watch exactly what happened.
+thea-recorder captures anything running in a virtual display — browser-based E2E tests, GUI applications, desktop automation scripts, product demos — as MP4, GIF, or WebM video with a live overlay bar showing status panels, step timelines, and custom context. It then generates an interactive HTML report where you can click any step and watch exactly what happened.
 
 ## Why
 
@@ -16,7 +16,7 @@ When something visual runs in CI — a test, a demo, a GUI app — and it fails,
 
 This is absurd. The screen was *right there* doing the thing. You just weren't watching.
 
-thea-recorder fixes this by recording the virtual display during execution. Every session gets its own MP4. The panel overlay shows you the current status and any custom context you want. The HTML report lets you click a step and the video seeks to that exact moment.
+thea-recorder fixes this by recording the virtual display during execution. Every session gets its own MP4 (with optional GIF or WebM conversion). The panel overlay shows you the current status and any custom context you want. The HTML report lets you click a step and the video seeks to that exact moment.
 
 **You stop guessing. You start watching.**
 
@@ -38,6 +38,7 @@ If it has a window and can run on X11, thea can record it.
 - **CLI** — server mode and client mode, scriptable from any language
 - **Panel overlay system** — named columns below the viewport with live-updating text
 - **Smart scrolling** — panels auto-scroll to keep the active content visible
+- **GIF and WebM output** — convert recordings to GIF (palette-based, ideal for PRs) or WebM (VP9)
 - **Interactive HTML reports** — embedded videos with clickable step timelines
 - **Video composition** — tile multiple recordings side-by-side with highlight borders
 - **Framework agnostic** — works with any test runner, GUI app, or automation script
@@ -170,6 +171,19 @@ thea start-display
 thea start-recording --name my-test
 ```
 
+## Output Formats
+
+Recordings are captured as MP4 by default. You can also produce GIF or WebM:
+
+- **GIF** — high-quality two-pass palette-based ffmpeg conversion (10fps, 720px width by default). Perfect for embedding in Pull Requests.
+- **WebM** — VP9 encoding for efficient web-friendly video.
+
+Three ways to get alternate formats:
+
+1. **CLI**: `thea stop-recording --gif` or `thea stop-recording --output-format gif`. Convert existing recordings with `thea convert-gif --name my_test` or `thea convert --name my_test --format webm`.
+2. **API/SDK**: `client.stop_recording(gif=True)` or `client.stop_recording(output_formats=["gif", "webm"])`.
+3. **HTTP**: `POST /recordings/<name>/gif` or `POST /recordings/<name>/webm` to convert existing recordings. `GET /recordings/<name>?format=gif` to download in a specific format.
+
 ## Docker
 
 ```dockerfile
@@ -244,7 +258,7 @@ The HTML report is a single self-contained file with:
 | `remove_panel(name)` | Remove a panel |
 | `update_panel(name, text, focus_line)` | Update panel content |
 | `start_recording(filename)` | Start ffmpeg capture |
-| `stop_recording()` | Stop capture, return MP4 path |
+| `stop_recording(gif, output_formats)` | Stop capture, return path(s). Optional `gif=True` or `output_formats=["gif","webm"]` for format conversion |
 | `recording_elapsed` | Seconds since recording started |
 | `cleanup()` | Stop everything, remove temp files |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,7 +99,50 @@ thea elapsed
 
 # Stop recording (prints path and elapsed)
 thea stop-recording
+
+# Stop recording and also produce a GIF
+thea stop-recording --gif
+
+# Stop recording and produce specific output formats
+thea stop-recording --output-format gif
+thea stop-recording --output-format webm
+
+# Convert an existing recording to GIF
+thea convert-gif --name login_test
+
+# Convert an existing recording to any format
+thea convert --name login_test --format gif
+thea convert --name login_test --format webm
 ```
+
+#### stop-recording flags
+
+| Flag | Description |
+|---|---|
+| `--gif` | Also produce a GIF version of the recording |
+| `--output-format` | Output format to produce in addition to MP4 (`gif` or `webm`) |
+
+#### convert-gif
+
+Converts an existing MP4 recording to GIF using a high-quality two-pass palette-based ffmpeg conversion (10fps, 720px width by default). GIFs are perfect for embedding in Pull Requests.
+
+```bash
+thea convert-gif --name login_test
+```
+
+#### convert
+
+Converts an existing MP4 recording to the specified format.
+
+```bash
+thea convert --name login_test --format gif
+thea convert --name login_test --format webm
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--name` | yes | Name of the recording to convert |
+| `--format` | yes | Target format (`gif` or `webm`) |
 
 ### Annotations
 

--- a/docs/how-recording-works.md
+++ b/docs/how-recording-works.md
@@ -439,4 +439,9 @@ rec.stop_recording()
 
 1. Sends `q` to ffmpeg's stdin (graceful quit)
 2. ffmpeg finalises the MP4 (writes moov atom, flushes buffers)
-3. The finished video file is ready to play
+3. The finished MP4 video file is ready to play
+4. If GIF or WebM output was requested (via `gif=True` or `output_formats`),
+   Thea runs additional ffmpeg passes to convert the MP4:
+   - **GIF**: a two-pass palette-based conversion (10fps, 720px width by default)
+     produces a high-quality GIF suitable for embedding in Pull Requests
+   - **WebM**: a VP9 encode produces an efficient web-friendly video

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -16,7 +16,7 @@ How to integrate the recorder into your existing workflow. Each example shows th
                                └──────┬───────────┘
                                       │
                                ┌──────┴───────────┐
-                               │  MP4 files +      │
+                               │  MP4/GIF/WebM +   │
                                │  HTML report      │
                                └──────────────────┘
 ```
@@ -316,3 +316,4 @@ class LoginTest {
 - **Use `/dashboard` in Docker** — expose port 9123 and open `http://localhost:9123/dashboard` in your browser to monitor all sessions from the host.
 - **Watch tests live** — use `display_stream_url()` or `display_viewer_url()` to stream the virtual display in real-time from your Docker host while tests are running.
 - **Generate CI report thumbnails** — use `recording_screenshot(name, time)` to extract a frame from a finished recording for use as a thumbnail in CI reports.
+- **Use GIF output for Pull Requests** — pass `gif=True` when stopping a recording (or use `convert_to_gif()` afterward) to produce a high-quality GIF that can be embedded directly in PR descriptions and comments. GIFs auto-play on GitHub, making test failures immediately visible to reviewers.

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -84,13 +84,15 @@ Every SDK provides:
 | `remove_panel(name)` | Remove panel |
 | `list_panels()` | List all panels |
 | `start_recording(name)` | Begin recording |
-| `stop_recording()` | Stop recording, get path + elapsed |
+| `stop_recording(gif, output_formats)` | Stop recording, get path + elapsed. Optional `gif=True` or `output_formats=["gif","webm"]` for format conversion |
 | `recording_elapsed()` | Get elapsed seconds |
 | `recording_status()` | Get recording state |
 | `add_annotation(label, time, details)` | Add a timestamped annotation to the active recording |
 | `list_annotations()` | List annotations for the active recording |
-| `list_recordings()` | List available MP4 files |
-| `download_recording(name, path)` | Download MP4 to local file |
+| `convert_to_gif(name)` | Convert an existing recording to GIF (two-pass palette-based, 10fps, 720px width) |
+| `convert_to_webm(name)` | Convert an existing recording to WebM (VP9) |
+| `list_recordings()` | List available recordings (includes `formats_available` per entry) |
+| `download_recording(name, path, format)` | Download recording to local file. Optional `format` (`"gif"`, `"webm"`) to download a converted version |
 | `recording_info(name)` | Get file metadata |
 | `display_screenshot(quality)` | Capture a JPEG screenshot of the live display |
 | `display_stream_url(fps)` | Get the MJPEG stream URL |

--- a/docs/server.md
+++ b/docs/server.md
@@ -178,10 +178,37 @@ If there are layout validation issues, the response includes a `warnings` array:
 ```bash
 curl -X POST http://localhost:9123/recording/stop
 ```
+
+Optional body to request format conversion:
+```json
+{"gif": true}
+```
+or:
+```json
+{"output_formats": ["gif", "webm"]}
+```
+
 **Response** `200`:
 ```json
 {"path": "/app/recordings/login_test.mp4", "elapsed": 45.2, "name": "login_test"}
 ```
+
+When format conversion is requested, additional paths are included:
+```json
+{
+  "path": "/app/recordings/login_test.mp4",
+  "elapsed": 45.2,
+  "name": "login_test",
+  "gif_path": "/app/recordings/login_test.gif",
+  "webm_path": "/app/recordings/login_test.webm"
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `gif` | no | If `true`, convert the recording to GIF after stopping |
+| `output_formats` | no | Array of formats to produce, e.g. `["gif", "webm"]` |
+
 **Error** `409` if not recording.
 
 #### Get elapsed time
@@ -255,16 +282,26 @@ curl http://localhost:9123/recordings
     "name": "login_test",
     "path": "/app/recordings/login_test.mp4",
     "size": 1234567,
-    "created": "2026-03-10T14:30:00+00:00"
+    "created": "2026-03-10T14:30:00+00:00",
+    "formats_available": ["mp4", "gif"]
   }
 ]
 ```
+
+The `formats_available` array lists all formats that exist on disk for this recording (e.g. `["mp4"]`, `["mp4", "gif"]`, `["mp4", "gif", "webm"]`).
 
 #### Download recording
 ```bash
 curl -O http://localhost:9123/recordings/login_test
 ```
 **Response** `200` with `Content-Type: video/mp4` and `Content-Disposition: attachment`.
+
+Use the `format` query parameter to download in a specific format:
+```bash
+curl -O http://localhost:9123/recordings/login_test?format=gif
+curl -O http://localhost:9123/recordings/login_test?format=webm
+```
+**Error** `404` if the requested format has not been generated yet.
 
 **Range requests** for video seeking:
 ```bash
@@ -307,6 +344,30 @@ curl http://localhost:9123/recordings/login_test/info
   "created": "2026-03-10T14:30:00+00:00"
 }
 ```
+
+#### Convert recording to GIF
+```bash
+curl -X POST http://localhost:9123/recordings/login_test/gif
+```
+Converts an existing MP4 recording to GIF using a high-quality two-pass palette-based ffmpeg conversion (10fps, 720px width by default).
+
+**Response** `200`:
+```json
+{"path": "/app/recordings/login_test.gif", "size": 2345678}
+```
+**Error** `404` if recording doesn't exist.
+
+#### Convert recording to WebM
+```bash
+curl -X POST http://localhost:9123/recordings/login_test/webm
+```
+Converts an existing MP4 recording to WebM using VP9 encoding.
+
+**Response** `200`:
+```json
+{"path": "/app/recordings/login_test.webm", "size": 987654}
+```
+**Error** `404` if recording doesn't exist.
 
 ### Layout Validation
 

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -33,6 +33,9 @@ recorder.update_panel("log", "Step 1: Launching application\nStep 2: Performing 
 video_path = recorder.stop_recording()
 print(f"Video saved: {video_path}")
 
+# To produce a GIF instead of MP4, pass output_format="gif":
+#   video_path = recorder.stop_recording(output_format="gif")
+
 # 6. Generate an HTML report
 videos = [
     {

--- a/examples/behave_environment.py
+++ b/examples/behave_environment.py
@@ -110,6 +110,7 @@ def after_scenario(context, scenario):
     recorder.update_panel("status", scenario.status.name.upper())
     time.sleep(0.5)
     steps = list(context._step_events)
+    # Pass output_format="gif" to stop_recording() for GIF output.
     video_path = recorder.stop_recording()
     if video_path:
         context.recorded_videos.append({

--- a/examples/product_demo.py
+++ b/examples/product_demo.py
@@ -1,8 +1,8 @@
 """Product demo orchestration with thea-recorder.
 
 Records a scripted walkthrough of an application and produces a
-polished MP4 — no test framework required.  Run this from a CI pipeline
-or a developer's laptop to generate a fresh demo video on demand.
+polished MP4 (or GIF) — no test framework required.  Run this from a CI
+pipeline or a developer's laptop to generate a fresh demo video on demand.
 
 Requirements:
   - thea serve running  (thea serve --port 9123 --output-dir ./recordings)

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -76,14 +76,16 @@ func main() {
 | Method | Description |
 |--------|-------------|
 | `StartRecording(ctx, name)` | Begin recording |
-| `StopRecording(ctx)` | Stop recording, returns `*RecordingResult` |
-| `Recording(ctx, name)` | Returns a `stop` func — ideal with `defer` |
+| `StopRecording(ctx, opts...)` | Stop recording, returns `*RecordingResult`. Pass `StopRecordingOptions` to request GIF/WebM output. |
+| `Recording(ctx, name, opts...)` | Returns a `stop` func — ideal with `defer`. Accepts optional `StopRecordingOptions`. |
+| `ConvertToGIF(ctx, name, fps, width)` | Convert an existing recording to GIF |
 | `RecordingElapsed(ctx)` | Elapsed seconds of current recording |
 | `RecordingStatusInfo(ctx)` | Full recording status |
 | `ListRecordings(ctx)` | List all stored recordings |
-| `GetRecordingInfo(ctx, name)` | Metadata for a single recording |
-| `DownloadRecording(ctx, name, w)` | Stream MP4 to an `io.Writer` |
-| `DownloadRecordingToFile(ctx, name, path)` | Download MP4 to a local file |
+| `GetRecordingInfo(ctx, name)` | Metadata for a single recording (includes GIF/WebM info if available) |
+| `DownloadRecording(ctx, name, w)` | Stream recording to an `io.Writer` |
+| `DownloadRecordingFormat(ctx, name, format, w)` | Stream recording in a specific format (`"mp4"`, `"gif"`, `"webm"`) to an `io.Writer` |
+| `DownloadRecordingToFile(ctx, name, path)` | Download recording to a local file |
 
 ### Utility
 
@@ -102,6 +104,42 @@ var recErr *thea.RecorderError
 if errors.As(err, &recErr) {
     log.Printf("HTTP %d: %s", recErr.StatusCode, recErr.Body)
 }
+```
+
+## GIF / WebM output
+
+You can request GIF (or other format) output when stopping a recording:
+
+```go
+result, err := client.StopRecording(ctx, thea.StopRecordingOptions{
+    GIF:      true,
+    GIFFps:   10,
+    GIFWidth: 640,
+})
+// result.GifPath contains the path to the generated GIF.
+// result.ExtraPaths has any additional output format paths.
+```
+
+Or convert an existing recording after the fact:
+
+```go
+info, err := client.ConvertToGIF(ctx, "demo", 10, 640)
+```
+
+To download a recording in a specific format:
+
+```go
+f, _ := os.Create("demo.gif")
+defer f.Close()
+client.DownloadRecordingFormat(ctx, "demo", "gif", f)
+```
+
+The `Recording` helper also accepts options:
+
+```go
+stop, err := client.Recording(ctx, "demo", thea.StopRecordingOptions{GIF: true})
+if err != nil { log.Fatal(err) }
+defer stop()
 ```
 
 ## Testing

--- a/sdks/go/thea/recorder.go
+++ b/sdks/go/thea/recorder.go
@@ -74,9 +74,11 @@ type Health struct {
 
 // RecordingResult is the payload returned by POST /recording/stop.
 type RecordingResult struct {
-	Path    string  `json:"path"`
-	Elapsed float64 `json:"elapsed"`
-	Name    string  `json:"name"`
+	Path       string            `json:"path"`
+	Elapsed    float64           `json:"elapsed"`
+	Name       string            `json:"name"`
+	GifPath    string            `json:"gif_path,omitempty"`
+	ExtraPaths map[string]string `json:"extra_paths,omitempty"`
 }
 
 // RecordingStatus is the payload returned by GET /recording/status.
@@ -88,10 +90,15 @@ type RecordingStatus struct {
 
 // RecordingInfo describes a single recording file.
 type RecordingInfo struct {
-	Name    string  `json:"name"`
-	Path    string  `json:"path"`
-	Size    int64   `json:"size"`
-	Created string  `json:"created"`
+	Name             string   `json:"name"`
+	Path             string   `json:"path"`
+	Size             int64    `json:"size"`
+	Created          string   `json:"created"`
+	GifPath          string   `json:"gif_path,omitempty"`
+	GifSize          int64    `json:"gif_size,omitempty"`
+	WebmPath         string   `json:"webm_path,omitempty"`
+	WebmSize         int64    `json:"webm_size,omitempty"`
+	FormatsAvailable []string `json:"formats_available,omitempty"`
 }
 
 // CompositionHighlight describes a highlight applied to a recording within a
@@ -349,6 +356,14 @@ func (c *Client) WithPanel(ctx context.Context, name, title string, width int, h
 // Recording
 // ---------------------------------------------------------------------------
 
+// StopRecordingOptions configures additional output formats when stopping.
+type StopRecordingOptions struct {
+	GIF           bool     `json:"gif,omitempty"`
+	GIFFps        int      `json:"gif_fps,omitempty"`
+	GIFWidth      int      `json:"gif_width,omitempty"`
+	OutputFormats []string `json:"output_formats,omitempty"`
+}
+
 // StartRecording begins recording (POST /recording/start).
 func (c *Client) StartRecording(ctx context.Context, name string) (*StartRecordingResult, error) {
 	body := map[string]any{"name": name}
@@ -360,12 +375,28 @@ func (c *Client) StartRecording(ctx context.Context, name string) (*StartRecordi
 }
 
 // StopRecording stops the active recording (POST /recording/stop).
-func (c *Client) StopRecording(ctx context.Context) (*RecordingResult, error) {
+// Optional StopRecordingOptions can request additional output formats (e.g. GIF).
+func (c *Client) StopRecording(ctx context.Context, opts ...StopRecordingOptions) (*RecordingResult, error) {
+	var body any
+	if len(opts) > 0 {
+		body = opts[0]
+	}
 	var result RecordingResult
-	if err := c.doJSON(ctx, http.MethodPost, "/recording/stop", nil, http.StatusOK, &result); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, "/recording/stop", body, http.StatusOK, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
+}
+
+// ConvertToGIF converts an existing recording to GIF
+// (POST /recordings/{name}/gif).
+func (c *Client) ConvertToGIF(ctx context.Context, name string, fps, width int) (map[string]any, error) {
+	body := map[string]any{"fps": fps, "width": width}
+	var result map[string]any
+	if err := c.doJSON(ctx, http.MethodPost, "/recordings/"+name+"/gif", body, http.StatusCreated, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // RecordingElapsed returns the elapsed time of the current recording
@@ -436,7 +467,7 @@ func (c *Client) RecordingScreenshot(ctx context.Context, name string, timeOffse
 	return c.doRawGet(ctx, path)
 }
 
-// DownloadRecording streams the MP4 for the named recording into w
+// DownloadRecording streams the recording for the named recording into w
 // (GET /recordings/{name}).
 func (c *Client) DownloadRecording(ctx context.Context, name string, w io.Writer) error {
 	if err := c.ensureReady(ctx); err != nil {
@@ -473,6 +504,30 @@ func (c *Client) DownloadRecordingToFile(ctx context.Context, name, filePath str
 	return f.Close()
 }
 
+// DownloadRecordingFormat streams a recording in the given format into w
+// (GET /recordings/{name}?format=...). Format can be "mp4", "gif", or "webm".
+func (c *Client) DownloadRecordingFormat(ctx context.Context, name, format string, w io.Writer) error {
+	if err := c.ensureReady(ctx); err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/recordings/%s?format=%s", c.baseURL, name, format)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		body, _ := io.ReadAll(resp.Body)
+		return &RecorderError{StatusCode: resp.StatusCode, Status: resp.Status, Body: string(body)}
+	}
+	_, err = io.Copy(w, resp.Body)
+	return err
+}
+
 // Recording is a context-manager-style helper. It starts a recording and
 // returns a stop function. Calling stop (or deferring it) will stop the
 // recording and return the result.
@@ -480,12 +535,12 @@ func (c *Client) DownloadRecordingToFile(ctx context.Context, name, filePath str
 //	stop, err := client.Recording(ctx, "demo")
 //	if err != nil { ... }
 //	defer stop()
-func (c *Client) Recording(ctx context.Context, name string) (stop func() (*RecordingResult, error), err error) {
+func (c *Client) Recording(ctx context.Context, name string, opts ...StopRecordingOptions) (stop func() (*RecordingResult, error), err error) {
 	if _, err := c.StartRecording(ctx, name); err != nil {
 		return nil, err
 	}
 	return func() (*RecordingResult, error) {
-		return c.StopRecording(ctx)
+		return c.StopRecording(ctx, opts...)
 	}, nil
 }
 

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -75,14 +75,49 @@ client.startRecording("test-session");
 // ... perform actions ...
 RecordingResult result = client.stopRecording();
 
+// Stop with GIF generation
+RecordingResult result = client.stopRecording(true, 10, 800);
+System.out.println("GIF: " + result.gif_path());
+
+// Stop with specific output formats
+RecordingResult result = client.stopRecording(List.of("mp4", "gif", "webm"));
+System.out.println("Extra paths: " + result.extra_paths());
+
 // Scoped recording
 RecordingResult result = client.recording("test-session", c -> {
     // recording is active here
 });
 
+// Scoped recording with GIF options
+RecordingResult result = client.recording("test-session", c -> {
+    // recording is active here
+}, true, 10, 800);
+
+// Scoped recording with output formats
+RecordingResult result = client.recording("test-session", c -> {
+    // recording is active here
+}, List.of("mp4", "gif", "webm"));
+
 // Status
 RecordingStatus status = client.recordingStatus();
 double elapsed = client.recordingElapsed();
+```
+
+### GIF / WebM Output
+
+```java
+// Convert an existing recording to GIF
+Map<String, Object> gifResult = client.convertToGif("my-recording", 10, 800);
+
+// Download a recording in a specific format
+client.downloadRecording("my-recording", Path.of("output.gif"), "gif");
+client.downloadRecording("my-recording", Path.of("output.webm"), "webm");
+
+// Check available formats for a recording
+RecordingInfo info = client.recordingInfo("my-recording");
+System.out.println("Formats: " + info.formats_available());
+System.out.println("GIF path: " + info.gif_path());
+System.out.println("WebM path: " + info.webm_path());
 ```
 
 ### Recordings
@@ -93,6 +128,9 @@ RecordingInfo info = client.recordingInfo("my-recording");
 
 // Download to file
 client.downloadRecording("my-recording", Path.of("output.mp4"));
+
+// Download in a specific format
+client.downloadRecording("my-recording", Path.of("output.gif"), "gif");
 
 // Download to stream
 try (var out = new FileOutputStream("output.mp4")) {
@@ -115,8 +153,8 @@ All responses use Java records:
 | Record            | Fields                                        |
 |-------------------|-----------------------------------------------|
 | `Panel`           | `name`, `title`, `width`                      |
-| `RecordingResult` | `name`, `path`, `elapsed`                     |
-| `RecordingInfo`   | `name`, `path`, `size`, `created`             |
+| `RecordingResult` | `name`, `path`, `elapsed`, `gif_path`, `extra_paths` |
+| `RecordingInfo`   | `name`, `path`, `size`, `created`, `gif_path`, `gif_size`, `webm_path`, `webm_size`, `formats_available` |
 | `RecordingStatus` | `recording`, `name`, `elapsed`                |
 | `Health`          | `status`, `recording`, `display`, `panels`, `uptime` |
 

--- a/sdks/java/src/main/java/com/recorder/RecorderClient.java
+++ b/sdks/java/src/main/java/com/recorder/RecorderClient.java
@@ -234,6 +234,42 @@ public class RecorderClient implements AutoCloseable {
     }
 
     /**
+     * Stops the current recording with GIF generation options.
+     *
+     * @param gif      whether to generate a GIF
+     * @param gifFps   frames per second for the GIF
+     * @param gifWidth width in pixels for the GIF
+     * @return the recording result
+     */
+    public RecordingResult stopRecording(boolean gif, int gifFps, int gifWidth) {
+        if (!gif) {
+            return stopRecording();
+        }
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("gif", "true");
+        fields.put("gif_fps", String.valueOf(gifFps));
+        fields.put("gif_width", String.valueOf(gifWidth));
+        var json = post("/recording/stop", jsonObject(fields), 200);
+        return parseRecordingResult(json);
+    }
+
+    /**
+     * Stops the current recording with specific output formats.
+     *
+     * @param outputFormats list of desired output formats (e.g. "mp4", "gif", "webm")
+     * @return the recording result
+     */
+    public RecordingResult stopRecording(List<String> outputFormats) {
+        if (outputFormats == null || outputFormats.isEmpty()) {
+            return stopRecording();
+        }
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("output_formats", jsonStringArray(outputFormats));
+        var json = post("/recording/stop", jsonObject(fields), 200);
+        return parseRecordingResult(json);
+    }
+
+    /**
      * Gets the elapsed time of the current recording.
      *
      * @return elapsed seconds
@@ -273,6 +309,56 @@ public class RecorderClient implements AutoCloseable {
             throw e;
         }
         return stopRecording();
+    }
+
+    /**
+     * Scoped recording helper with GIF generation options.
+     *
+     * @param name     recording name
+     * @param action   action to run while recording
+     * @param gif      whether to generate a GIF
+     * @param gifFps   frames per second for the GIF
+     * @param gifWidth width in pixels for the GIF
+     * @return the recording result
+     */
+    public RecordingResult recording(String name, Consumer<RecorderClient> action,
+                                     boolean gif, int gifFps, int gifWidth) {
+        startRecording(name);
+        try {
+            action.accept(this);
+        } catch (Exception e) {
+            try {
+                stopRecording();
+            } catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
+        }
+        return stopRecording(gif, gifFps, gifWidth);
+    }
+
+    /**
+     * Scoped recording helper with specific output formats.
+     *
+     * @param name          recording name
+     * @param action        action to run while recording
+     * @param outputFormats list of desired output formats (e.g. "mp4", "gif", "webm")
+     * @return the recording result
+     */
+    public RecordingResult recording(String name, Consumer<RecorderClient> action,
+                                     List<String> outputFormats) {
+        startRecording(name);
+        try {
+            action.accept(this);
+        } catch (Exception e) {
+            try {
+                stopRecording();
+            } catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
+        }
+        return stopRecording(outputFormats);
     }
 
     // ── Annotations ─────────────────────────────────────────────────────
@@ -380,6 +466,49 @@ public class RecorderClient implements AutoCloseable {
     public RecordingInfo recordingInfo(String name) {
         var json = get("/recordings/" + encode(name) + "/info", 200);
         return parseRecordingInfo(json);
+    }
+
+    /**
+     * Converts a recording to GIF format.
+     *
+     * @param name  recording name
+     * @param fps   frames per second for the GIF
+     * @param width width in pixels for the GIF
+     * @return conversion result as a map
+     */
+    public Map<String, Object> convertToGif(String name, int fps, int width) {
+        var fields = new LinkedHashMap<String, String>();
+        fields.put("fps", String.valueOf(fps));
+        fields.put("width", String.valueOf(width));
+        var json = post("/recordings/" + encode(name) + "/gif", jsonObject(fields), 200);
+        return parseJsonObject(json);
+    }
+
+    /**
+     * Downloads a recording in a specific format.
+     *
+     * @param name        recording name
+     * @param destination destination path
+     * @param format      output format (e.g. "mp4", "gif", "webm")
+     */
+    public void downloadRecording(String name, Path destination, String format) {
+        String query = "mp4".equals(format) ? "" : "?format=" + encode(format);
+        String path = "/recordings/" + encode(name) + query;
+        ensureReady(path);
+        var request = newRequest(path)
+                .GET()
+                .build();
+        try {
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofFile(destination));
+            if (response.statusCode() != 200) {
+                throw new RecorderError(response.statusCode(),
+                        "Download failed: HTTP " + response.statusCode());
+            }
+        } catch (RecorderError e) {
+            throw e;
+        } catch (IOException | InterruptedException e) {
+            throw new RecorderError("Download failed", e);
+        }
     }
 
     /**
@@ -1214,6 +1343,60 @@ public class RecorderClient implements AutoCloseable {
     }
 
     /**
+     * Builds a JSON array of strings, e.g. ["a", "b", "c"].
+     */
+    static String jsonStringArray(List<String> values) {
+        var sb = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(jsonString(values.get(i)));
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    /**
+     * Parses a flat JSON object of string values into a Map, e.g. {"a":"x","b":"y"}.
+     */
+    static Map<String, String> parseStringMap(String json) {
+        var result = new LinkedHashMap<String, String>();
+        if (json == null) return result;
+        json = json.strip();
+        if (!json.startsWith("{") || !json.endsWith("}")) return result;
+        json = json.substring(1, json.length() - 1).strip();
+        if (json.isEmpty()) return result;
+        // Split by commas at the top level
+        int depth = 0;
+        boolean inStr = false;
+        int start = 0;
+        for (int i = 0; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (c == '\\' && inStr) { i++; continue; }
+            if (c == '"') inStr = !inStr;
+            else if (!inStr) {
+                if (c == '{' || c == '[') depth++;
+                else if (c == '}' || c == ']') depth--;
+                else if (c == ',' && depth == 0) {
+                    parseStringMapEntry(json.substring(start, i).strip(), result);
+                    start = i + 1;
+                }
+            }
+        }
+        parseStringMapEntry(json.substring(start).strip(), result);
+        return result;
+    }
+
+    private static void parseStringMapEntry(String entry, Map<String, String> map) {
+        int colon = entry.indexOf(':');
+        if (colon < 0) return;
+        String key = entry.substring(0, colon).strip();
+        String val = entry.substring(colon + 1).strip();
+        if (key.startsWith("\"") && key.endsWith("\"")) key = key.substring(1, key.length() - 1);
+        if (val.startsWith("\"") && val.endsWith("\"")) val = val.substring(1, val.length() - 1);
+        map.put(key, val);
+    }
+
+    /**
      * Parses a JSON array of strings, e.g. ["a", "b", "c"].
      */
     static List<String> parseStringArray(String json) {
@@ -1300,19 +1483,30 @@ public class RecorderClient implements AutoCloseable {
     // ── JSON → Record parsers ────────────────────────────────────────────
 
     private RecordingResult parseRecordingResult(String json) {
+        var extraPathsRaw = jsonRawValue(json, "extra_paths");
+        Map<String, String> extraPaths = extraPathsRaw != null ? parseStringMap(extraPathsRaw) : null;
         return new RecordingResult(
                 jsonValue(json, "name"),
                 jsonValue(json, "path"),
-                parseDouble(jsonValue(json, "elapsed"))
+                parseDouble(jsonValue(json, "elapsed")),
+                jsonValue(json, "gif_path"),
+                extraPaths
         );
     }
 
     private RecordingInfo parseRecordingInfo(String json) {
+        var formatsRaw = jsonRawValue(json, "formats_available");
+        List<String> formats = formatsRaw != null ? parseStringArray(formatsRaw) : null;
         return new RecordingInfo(
                 jsonValue(json, "name"),
                 jsonValue(json, "path"),
                 parseLong(jsonValue(json, "size")),
-                jsonValue(json, "created")
+                jsonValue(json, "created"),
+                jsonValue(json, "gif_path"),
+                parseLong(jsonValue(json, "gif_size")),
+                jsonValue(json, "webm_path"),
+                parseLong(jsonValue(json, "webm_size")),
+                formats
         );
     }
 
@@ -1471,12 +1665,7 @@ public class RecorderClient implements AutoCloseable {
         var elements = jsonArrayElements(json);
         var list = new ArrayList<RecordingInfo>(elements.size());
         for (var el : elements) {
-            list.add(new RecordingInfo(
-                    jsonValue(el, "name"),
-                    jsonValue(el, "path"),
-                    parseLong(jsonValue(el, "size")),
-                    jsonValue(el, "created")
-            ));
+            list.add(parseRecordingInfo(el));
         }
         return list;
     }

--- a/sdks/java/src/main/java/com/recorder/RecordingInfo.java
+++ b/sdks/java/src/main/java/com/recorder/RecordingInfo.java
@@ -1,12 +1,29 @@
 package com.recorder;
 
+import java.util.List;
+
 /**
  * Metadata about a stored recording.
  *
- * @param name    the recording name
- * @param path    the file path on the server
- * @param size    file size in bytes
- * @param created creation timestamp string
+ * @param name              the recording name
+ * @param path              the file path on the server
+ * @param size              file size in bytes
+ * @param created           creation timestamp string
+ * @param gif_path          path to the GIF file (null if not available)
+ * @param gif_size          GIF file size in bytes (0 if not available)
+ * @param webm_path         path to the WebM file (null if not available)
+ * @param webm_size         WebM file size in bytes (0 if not available)
+ * @param formats_available list of available output formats (null if not reported)
  */
-public record RecordingInfo(String name, String path, long size, String created) {
+public record RecordingInfo(String name, String path, long size, String created,
+                            String gif_path, long gif_size,
+                            String webm_path, long webm_size,
+                            List<String> formats_available) {
+
+    /**
+     * Backwards-compatible constructor without GIF/WebM fields.
+     */
+    public RecordingInfo(String name, String path, long size, String created) {
+        this(name, path, size, created, null, 0, null, 0, null);
+    }
 }

--- a/sdks/java/src/main/java/com/recorder/RecordingResult.java
+++ b/sdks/java/src/main/java/com/recorder/RecordingResult.java
@@ -1,11 +1,23 @@
 package com.recorder;
 
+import java.util.Map;
+
 /**
  * Result returned when a recording is stopped.
  *
- * @param name    the recording name
- * @param path    the file path on the server
- * @param elapsed elapsed time in seconds
+ * @param name       the recording name
+ * @param path       the file path on the server
+ * @param elapsed    elapsed time in seconds
+ * @param gif_path   path to the generated GIF file (null if not requested)
+ * @param extra_paths additional output paths keyed by format (null if none)
  */
-public record RecordingResult(String name, String path, double elapsed) {
+public record RecordingResult(String name, String path, double elapsed,
+                              String gif_path, Map<String, String> extra_paths) {
+
+    /**
+     * Backwards-compatible constructor without GIF fields.
+     */
+    public RecordingResult(String name, String path, double elapsed) {
+        this(name, path, elapsed, null, null);
+    }
 }

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -66,7 +66,7 @@ new RecorderClient(options?: {
 | Method | Description |
 |--------|-------------|
 | `startRecording(name)` | Start recording with the given name |
-| `stopRecording()` | Stop recording; returns `{ path, elapsed, name }` |
+| `stopRecording(options?)` | Stop recording; returns `{ path, elapsed, name, gif_path?, extra_paths? }`. Pass `StopRecordingOptions` to produce GIF/WebM. |
 | `recordingElapsed()` | Get elapsed recording time |
 | `recordingStatus()` | Get recording status |
 
@@ -75,9 +75,10 @@ new RecorderClient(options?: {
 | Method | Description |
 |--------|-------------|
 | `listRecordings()` | List all recordings |
-| `downloadRecording(name)` | Download as `ReadableStream<Uint8Array>` |
-| `downloadRecordingToFile(name, path)` | Download and save to a local file |
-| `recordingInfo(name)` | Get metadata for a recording |
+| `convertToGif(name, options?)` | Convert an existing recording to GIF; options: `{ fps?, width? }` |
+| `downloadRecording(name, format?)` | Download as `ReadableStream<Uint8Array>`. Optional format: `"gif"`, `"webm"`. |
+| `downloadRecordingToFile(name, path, format?)` | Download and save to a local file. Optional format: `"gif"`, `"webm"`. |
+| `recordingInfo(name)` | Get metadata for a recording (includes `gif_path`, `webm_path`, `formats_available` when applicable) |
 
 ### System
 
@@ -94,6 +95,21 @@ new RecorderClient(options?: {
 const result = await client.recording("name", async () => {
   // ... your logic ...
 });
+
+// Record and also produce a GIF
+const result2 = await client.recording("name", async () => {
+  // ... your logic ...
+}, { gif: true, gif_fps: 10, gif_width: 720 });
+console.log(result2.gif_path); // path to the generated GIF
+
+// Stop with multiple output formats
+await client.stopRecording({ output_formats: ["gif", "webm"] });
+
+// Convert an existing recording to GIF
+const gif = await client.convertToGif("my-recording", { fps: 10, width: 720 });
+
+// Download a specific format
+await client.downloadRecordingToFile("my-recording", "output.gif", "gif");
 
 // Scoped panel — removed automatically when fn completes or throws
 await client.withPanel("code", "Source Code", 80, async () => {

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -58,6 +58,20 @@ export interface StopRecordingResponse {
   path: string;
   elapsed: number;
   name: string;
+  gif_path?: string;
+  extra_paths?: Record<string, string>;
+}
+
+/** Options for stopping a recording with additional output formats. */
+export interface StopRecordingOptions {
+  /** Also produce a GIF version. */
+  gif?: boolean;
+  /** GIF frame rate (default 10). */
+  gif_fps?: number;
+  /** GIF width in pixels (default 720). */
+  gif_width?: number;
+  /** Additional output formats to produce (e.g. ["gif", "webm"]). */
+  output_formats?: string[];
 }
 
 /** Response from GET /recording/elapsed. */
@@ -78,6 +92,11 @@ export interface RecordingInfo {
   path: string;
   size: number;
   created: string;
+  gif_path?: string;
+  gif_size?: number;
+  webm_path?: string;
+  webm_size?: number;
+  formats_available?: string[];
 }
 
 /** Response from GET /health. */
@@ -356,8 +375,19 @@ export class RecorderClient {
   }
 
   /** Stop recording (POST /recording/stop). */
-  async stopRecording(): Promise<StopRecordingResponse> {
-    return this.request<StopRecordingResponse>("POST", "/recording/stop");
+  async stopRecording(options?: StopRecordingOptions): Promise<StopRecordingResponse> {
+    return this.request<StopRecordingResponse>("POST", "/recording/stop", options);
+  }
+
+  /** Convert an existing recording to GIF (POST /recordings/{name}/gif). */
+  async convertToGif(
+    name: string,
+    options?: { fps?: number; width?: number },
+  ): Promise<{ name: string; gif_path: string; gif_size: number }> {
+    return this.request("POST", `/recordings/${encodeURIComponent(name)}/gif`, {
+      fps: options?.fps ?? 10,
+      width: options?.width ?? 720,
+    });
   }
 
   /** Get elapsed recording time (GET /recording/elapsed). */
@@ -400,10 +430,14 @@ export class RecorderClient {
    *
    * Returns the raw {@link Response} body stream.
    */
-  async downloadRecording(name: string): Promise<ReadableStream<Uint8Array>> {
+  async downloadRecording(
+    name: string,
+    format?: string,
+  ): Promise<ReadableStream<Uint8Array>> {
+    const query = format && format !== "mp4" ? `?format=${format}` : "";
     const res = await this.request(
       "GET",
-      `/recordings/${encodeURIComponent(name)}`,
+      `/recordings/${encodeURIComponent(name)}${query}`,
       undefined,
       true,
     );
@@ -419,10 +453,12 @@ export class RecorderClient {
   async downloadRecordingToFile(
     name: string,
     destPath: string,
+    format?: string,
   ): Promise<void> {
+    const query = format && format !== "mp4" ? `?format=${format}` : "";
     const res = await this.request(
       "GET",
-      `/recordings/${encodeURIComponent(name)}`,
+      `/recordings/${encodeURIComponent(name)}${query}`,
       undefined,
       true,
     );
@@ -795,6 +831,7 @@ export class RecorderClient {
   async recording(
     name: string,
     fn: () => Promise<void>,
+    options?: StopRecordingOptions,
   ): Promise<StopRecordingResponse> {
     await this.startRecording(name);
     let fnError: unknown;
@@ -803,7 +840,7 @@ export class RecorderClient {
     } catch (err) {
       fnError = err;
     }
-    const result = await this.stopRecording();
+    const result = await this.stopRecording(options);
     if (fnError !== undefined) {
       throw fnError;
     }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -35,6 +35,20 @@ for rec in client.list_recordings():
 
 # Download a recording
 client.download_recording("my-demo", "/tmp/my-demo.mp4")
+
+# Record with GIF output
+with client.recording("my-demo", gif=True, gif_fps=10) as info:
+    with client.panel("editor", "Code", 80) as panel:
+        client.update_panel("editor", "print('hello')", focus_line=1)
+print(info.gif_path)       # GIF path on server
+print(info.extra_paths)    # {"gif": "/path/to.gif"}
+
+# Download GIF/WebM variants
+client.download_recording("my-demo", "/tmp/my-demo.gif", format="gif")
+client.download_recording("my-demo", "/tmp/my-demo.webm", format="webm")
+
+# Convert an existing recording to GIF
+client.convert_to_gif("my-demo", fps=10, width=720)
 ```
 
 ## Configuration
@@ -61,14 +75,15 @@ client.download_recording("my-demo", "/tmp/my-demo.mp4")
 ### Recording
 
 - `start_recording(name)` — Start recording.
-- `stop_recording()` — Stop the current recording. Returns path, elapsed, and name.
+- `stop_recording(*, gif=False, gif_fps=10, gif_width=720, output_formats=None)` — Stop the current recording. Returns path, elapsed, name, and optionally `gif_path` and `extra_paths`. Set `gif=True` to also produce a GIF. Use `output_formats=["gif", "webm"]` for multiple output formats.
+- `convert_to_gif(name, *, fps=10, width=720)` — Convert an existing recording to GIF.
 - `recording_elapsed()` — Get seconds elapsed for the current recording.
 - `recording_status()` — Get full recording status.
 
 ### Recordings archive
 
 - `list_recordings()` — List all saved recordings.
-- `download_recording(name, path)` — Download an MP4 file to a local path.
+- `download_recording(name, path, *, format="mp4")` — Download a recording to a local path. Use `format="gif"` or `format="webm"` to download alternative formats.
 - `recording_info(name)` — Get metadata for a recording.
 
 ### Health and cleanup
@@ -79,7 +94,7 @@ client.download_recording("my-demo", "/tmp/my-demo.mp4")
 
 ### Context managers
 
-- `recording(name)` — Starts and stops a recording automatically.
+- `recording(name, *, gif=False, gif_fps=10, gif_width=720, output_formats=None)` — Starts and stops a recording automatically. Pass `gif=True` to produce a GIF alongside the MP4. The result object exposes `gif_path` and `extra_paths` attributes.
 - `panel(name, title, width)` — Creates and removes a panel automatically.
 
 ## Error handling

--- a/sdks/python/thea/client.py
+++ b/sdks/python/thea/client.py
@@ -27,18 +27,27 @@ class RecordingResult:
 
     Attributes
     ----------
-    name:    Recording name passed to ``start_recording``.
-    path:    Absolute path to the saved MP4 file on the server.
-    elapsed: Duration of the recording in seconds.
+    name:        Recording name passed to ``start_recording``.
+    path:        Absolute path to the saved MP4 file on the server.
+    elapsed:     Duration of the recording in seconds.
+    gif_path:    Path to the GIF file, if GIF output was requested.
+    extra_paths: Dict mapping format names to paths for additional outputs
+                 (e.g. ``{"gif": "/path/to.gif", "webm": "/path/to.webm"}``).
     """
 
     def __init__(self) -> None:
         self.name: str | None = None
         self.path: str | None = None
         self.elapsed: float | None = None
+        self.gif_path: str | None = None
+        self.extra_paths: dict[str, str] | None = None
 
     def __repr__(self) -> str:
-        return f"RecordingResult(name={self.name!r}, path={self.path!r}, elapsed={self.elapsed})"
+        return (
+            f"RecordingResult(name={self.name!r}, path={self.path!r}, "
+            f"elapsed={self.elapsed}, gif_path={self.gif_path!r}, "
+            f"extra_paths={self.extra_paths!r})"
+        )
 
 
 class CompositionHelper:
@@ -284,12 +293,57 @@ class RecorderClient:
         """POST /recording/start — begin recording."""
         return self._request("POST", "/recording/start", {"name": name})
 
-    def stop_recording(self) -> dict[str, Any]:
+    def stop_recording(
+        self,
+        *,
+        gif: bool = False,
+        gif_fps: int = 10,
+        gif_width: int = 720,
+        output_formats: list[str] | None = None,
+    ) -> dict[str, Any]:
         """POST /recording/stop — stop current recording.
 
-        Returns dict with ``path``, ``elapsed``, and ``name``.
+        Parameters
+        ----------
+        gif:
+            If *True*, also produce a GIF of the recording.
+        gif_fps:
+            Frames per second for the GIF (default 10).
+        gif_width:
+            Width in pixels for the GIF (default 720).
+        output_formats:
+            Additional output formats to produce (e.g. ``["gif", "webm"]``).
+
+        Returns dict with ``path``, ``elapsed``, ``name``, and optionally
+        ``gif_path`` and ``extra_paths``.
         """
-        return self._request("POST", "/recording/stop")
+        payload: dict[str, Any] = {}
+        if gif:
+            payload["gif"] = True
+            payload["gif_fps"] = gif_fps
+            payload["gif_width"] = gif_width
+        if output_formats is not None:
+            payload["output_formats"] = output_formats
+        return self._request("POST", "/recording/stop", payload or None)
+
+    def convert_to_gif(self, name: str, *, fps: int = 10, width: int = 720) -> dict[str, Any]:
+        """POST /recordings/{name}/gif — convert an existing recording to GIF.
+
+        Parameters
+        ----------
+        name:
+            Name of the recording to convert.
+        fps:
+            Frames per second for the GIF (default 10).
+        width:
+            Width in pixels for the GIF (default 720).
+
+        Returns
+        -------
+        dict
+            Server response with the path to the generated GIF.
+        """
+        return self._request("POST", f"/recordings/{name}/gif", {"fps": fps, "width": width})
 
     def recording_elapsed(self) -> dict[str, Any]:
         """GET /recording/elapsed — seconds elapsed for current recording."""
@@ -356,12 +410,25 @@ class RecorderClient:
             return result  # type: ignore[return-value]
         return []
 
-    def download_recording(self, name: str, path: str) -> str:
-        """GET /recordings/{name} — download an MP4 to *path*.
+    def download_recording(self, name: str, path: str, *, format: str = "mp4") -> str:
+        """GET /recordings/{name} — download a recording to *path*.
+
+        Parameters
+        ----------
+        name:
+            Recording name.
+        path:
+            Local filesystem path to write the file to.
+        format:
+            Output format to download (``"mp4"``, ``"gif"``, ``"webm"``).
+            Defaults to ``"mp4"``.
 
         Returns the path written to.
         """
-        data = self._request_raw("GET", f"/recordings/{name}")
+        url = f"/recordings/{name}"
+        if format != "mp4":
+            url = f"{url}?format={format}"
+        data = self._request_raw("GET", url)
         with open(path, "wb") as fh:
             fh.write(data)
         return path
@@ -922,7 +989,13 @@ class RecorderClient:
 
     @contextmanager
     def recording(
-        self, name: str
+        self,
+        name: str,
+        *,
+        gif: bool = False,
+        gif_fps: int = 10,
+        gif_width: int = 720,
+        output_formats: list[str] | None = None,
     ) -> Generator[RecordingResult, None, None]:
         """Context manager that starts and stops a recording.
 
@@ -933,6 +1006,26 @@ class RecorderClient:
             print(result.path)     # MP4 path on server
             print(result.elapsed)  # duration in seconds
 
+        With GIF output::
+
+            with client.recording("demo", gif=True) as result:
+                ...
+            print(result.gif_path)    # GIF path on server
+            print(result.extra_paths) # {"gif": "/path/to.gif", ...}
+
+        Parameters
+        ----------
+        name:
+            Unique recording name.
+        gif:
+            If *True*, also produce a GIF of the recording.
+        gif_fps:
+            Frames per second for the GIF (default 10).
+        gif_width:
+            Width in pixels for the GIF (default 720).
+        output_formats:
+            Additional output formats to produce (e.g. ``["gif", "webm"]``).
+
         The recording is stopped (and the MP4 finalised) even if the
         body raises an exception.
         """
@@ -942,9 +1035,16 @@ class RecorderClient:
         try:
             yield result
         finally:
-            stop = self.stop_recording()
+            stop = self.stop_recording(
+                gif=gif,
+                gif_fps=gif_fps,
+                gif_width=gif_width,
+                output_formats=output_formats,
+            )
             result.path = stop.get("path")
             result.elapsed = stop.get("elapsed")
+            result.gif_path = stop.get("gif_path")
+            result.extra_paths = stop.get("extra_paths")
 
     @contextmanager
     def panel(

--- a/sdks/ruby/README.md
+++ b/sdks/ruby/README.md
@@ -41,6 +41,21 @@ puts "Recorded #{result['elapsed']}s to #{result['path']}"
 # Download the recording
 client.download_recording("demo", "/tmp/demo.mp4")
 
+# Stop recording and generate a GIF automatically
+client.start_recording(name: "gif-demo")
+# ... do work ...
+client.stop_recording(gif: true, gif_fps: 15, gif_width: 640)
+
+# Convert an existing recording to GIF
+client.convert_to_gif("demo", fps: 10, width: 720)
+
+# Download in different formats (mp4, gif, webm)
+client.download_recording("demo", "/tmp/demo.gif", format: "gif")
+client.download_recording("demo", "/tmp/demo.webm", format: "webm")
+
+# Stop recording with multiple output formats
+client.stop_recording(output_formats: ["mp4", "gif", "webm"])
+
 # Clean up
 client.remove_panel("editor")
 client.stop_display
@@ -59,6 +74,16 @@ client.recording("demo") do |r|
 end
 # Recording is stopped and panel is removed automatically,
 # even if an exception is raised inside the block.
+
+# Block syntax with GIF output
+client.recording("demo", gif: true, gif_fps: 15) do |r|
+  # ... do work ...
+end
+
+# Block syntax with multiple output formats
+client.recording("demo", output_formats: ["mp4", "webm"]) do |r|
+  # ... do work ...
+end
 ```
 
 ### Error handling
@@ -91,16 +116,17 @@ client = Recorder::Client.new("http://localhost:3000", timeout: 60)
 | `remove_panel(name)` | DELETE /panels/{name} | Remove a panel |
 | `list_panels` | GET /panels | List all panels |
 | `start_recording(name:)` | POST /recording/start | Start recording |
-| `stop_recording` | POST /recording/stop | Stop recording |
+| `stop_recording(gif:, gif_fps:, gif_width:, output_formats:)` | POST /recording/stop | Stop recording (optionally generate GIF/other formats) |
 | `recording_elapsed` | GET /recording/elapsed | Get elapsed time |
 | `recording_status` | GET /recording/status | Get recording status |
 | `list_recordings` | GET /recordings | List all recordings |
-| `download_recording(name, path)` | GET /recordings/{name} | Download MP4 to path |
+| `convert_to_gif(name, fps:, width:)` | POST /recordings/{name}/gif | Convert recording to GIF |
+| `download_recording(name, path, format:)` | GET /recordings/{name} | Download recording to path (format: mp4, gif, webm) |
 | `recording_info(name)` | GET /recordings/{name}/info | Get recording metadata |
 | `health` | GET /health | Health check |
 | `cleanup` | POST /cleanup | Clean up resources |
 | `wait_until_ready(timeout:)` | GET /health (polling) | Wait for server. Called automatically on first API call. |
-| `recording(name) { \|r\| ... }` | -- | Block with auto stop |
+| `recording(name, gif:, output_formats:) { \|r\| ... }` | -- | Block with auto stop (supports GIF/format options) |
 | `with_panel(name, ...) { ... }` | -- | Block with auto remove |
 
 ## Development

--- a/sdks/ruby/lib/recorder.rb
+++ b/sdks/ruby/lib/recorder.rb
@@ -78,8 +78,17 @@ module Recorder
       post("/recording/start", name: name)
     end
 
-    def stop_recording
-      post("/recording/stop")
+    def stop_recording(gif: false, gif_fps: 10, gif_width: 720, output_formats: nil)
+      body = {}
+      body[:gif] = true if gif
+      body[:gif_fps] = gif_fps if gif
+      body[:gif_width] = gif_width if gif
+      body[:output_formats] = output_formats if output_formats
+      post("/recording/stop", body.empty? ? nil : body)
+    end
+
+    def convert_to_gif(name, fps: 10, width: 720)
+      post("/recordings/#{encode(name)}/gif", fps: fps, width: width)
     end
 
     def recording_elapsed
@@ -101,11 +110,11 @@ module Recorder
       get("/recording/annotations")
     end
 
-    def recording(name)
+    def recording(name, gif: false, gif_fps: 10, gif_width: 720, output_formats: nil)
       start_recording(name: name)
       yield self
     ensure
-      stop_recording
+      stop_recording(gif: gif, gif_fps: gif_fps, gif_width: gif_width, output_formats: output_formats)
     end
 
     # Recordings
@@ -114,8 +123,9 @@ module Recorder
       get("/recordings")
     end
 
-    def download_recording(name, path)
-      response = raw_get("/recordings/#{encode(name)}")
+    def download_recording(name, path, format: "mp4")
+      query = format != "mp4" ? "?format=#{encode(format)}" : ""
+      response = raw_get("/recordings/#{encode(name)}#{query}")
       File.binwrite(path, response.body)
       path
     end

--- a/src/thea/cli.py
+++ b/src/thea/cli.py
@@ -319,12 +319,72 @@ def start_recording(ctx, name):
 
 
 @main.command("stop-recording")
+@click.option("--gif", is_flag=True, default=False, help="Also produce a GIF version (great for PRs).")
+@click.option("--gif-fps", default=10, type=int, help="GIF frame rate (default: 10).")
+@click.option("--gif-width", default=720, type=int, help="GIF width in pixels (default: 720).")
+@click.option("--output-format", "output_formats", multiple=True,
+              type=click.Choice(["gif", "webm"]),
+              help="Additional output format(s). Can be specified multiple times.")
 @click.pass_context
-def stop_recording(ctx):
+def stop_recording(ctx, gif, gif_fps, gif_width, output_formats):
     """Stop recording and print the video path."""
     server = _server_url(ctx)
+    payload = {}
+    if output_formats:
+        payload["output_formats"] = list(output_formats)
+    if gif:
+        payload["gif"] = True
+        payload["gif_fps"] = gif_fps
+        payload["gif_width"] = gif_width
     try:
-        status, data = _request(f"{server}/recording/stop", method="POST")
+        status, data = _request(f"{server}/recording/stop", method="POST", data=payload or None)
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("convert-gif")
+@click.option("--name", required=True, help="Recording name to convert.")
+@click.option("--fps", default=10, type=int, help="GIF frame rate (default: 10).")
+@click.option("--width", default=720, type=int, help="GIF width in pixels (default: 720).")
+@click.pass_context
+def convert_gif(ctx, name, fps, width):
+    """Convert an existing recording to GIF."""
+    server = _server_url(ctx)
+    try:
+        status, data = _request(
+            f"{server}/recordings/{name}/gif",
+            method="POST",
+            data={"fps": fps, "width": width},
+        )
+    except (URLError, ConnectionError, OSError):
+        _handle_connection_error(server)
+    if status >= 400:
+        click.echo(f"Error: {data.get('error', 'unknown')}", err=True)
+        sys.exit(1)
+    _print_result(data, ctx.obj["quiet"], ctx.obj["pretty"])
+
+
+@main.command("convert")
+@click.option("--name", required=True, help="Recording name to convert.")
+@click.option("--format", "fmt", required=True, type=click.Choice(["gif", "webm"]),
+              help="Target format.")
+@click.option("--fps", default=10, type=int, help="GIF frame rate (default: 10).")
+@click.option("--width", default=720, type=int, help="Width in pixels (default: 720, -1 for original).")
+@click.pass_context
+def convert(ctx, name, fmt, fps, width):
+    """Convert an existing recording to another format."""
+    server = _server_url(ctx)
+    payload = {"fps": fps, "width": width}
+    try:
+        status, data = _request(
+            f"{server}/recordings/{name}/{fmt}",
+            method="POST",
+            data=payload,
+        )
     except (URLError, ConnectionError, OSError):
         _handle_connection_error(server)
     if status >= 400:

--- a/src/thea/client.py
+++ b/src/thea/client.py
@@ -29,16 +29,23 @@ class RecordingResult:
     ----------
     name:    Recording name passed to ``start_recording``.
     path:    Absolute path to the saved MP4 file on the server.
+    gif_path: Absolute path to the GIF file, if GIF output was requested.
     elapsed: Duration of the recording in seconds.
     """
 
     def __init__(self) -> None:
         self.name: str | None = None
         self.path: str | None = None
+        self.gif_path: str | None = None
+        self.extra_paths: dict[str, str] | None = None
         self.elapsed: float | None = None
 
     def __repr__(self) -> str:
-        return f"RecordingResult(name={self.name!r}, path={self.path!r}, elapsed={self.elapsed})"
+        return (
+            f"RecordingResult(name={self.name!r}, path={self.path!r}, "
+            f"gif_path={self.gif_path!r}, extra_paths={self.extra_paths!r}, "
+            f"elapsed={self.elapsed})"
+        )
 
 
 class CompositionHelper:
@@ -320,12 +327,53 @@ class RecorderClient:
         """POST /recording/start — begin recording."""
         return self._request("POST", "/recording/start", {"name": name})
 
-    def stop_recording(self) -> dict[str, Any]:
+    def stop_recording(
+        self,
+        *,
+        gif: bool = False,
+        gif_fps: int = 10,
+        gif_width: int = 720,
+        output_formats: list[str] | None = None,
+    ) -> dict[str, Any]:
         """POST /recording/stop — stop current recording.
 
-        Returns dict with ``path``, ``elapsed``, and ``name``.
+        Args:
+            gif: If True, also convert the recording to GIF (shorthand).
+            gif_fps: Frame rate for the GIF (default 10).
+            gif_width: Width in pixels for the GIF (default 720).
+            output_formats: List of additional formats to produce, e.g.
+                ``["gif"]``, ``["gif", "webm"]``.
+
+        Returns dict with ``path``, ``elapsed``, ``name``, and
+        optionally ``gif_path`` and/or ``extra_paths``.
         """
-        return self._request("POST", "/recording/stop")
+        payload: dict[str, Any] = {}
+        if output_formats:
+            payload["output_formats"] = output_formats
+        if gif:
+            payload["gif"] = True
+            payload["gif_fps"] = gif_fps
+            payload["gif_width"] = gif_width
+        return self._request("POST", "/recording/stop", payload or None)
+
+    def convert_to_gif(
+        self,
+        name: str,
+        *,
+        fps: int = 10,
+        width: int = 720,
+    ) -> dict[str, Any]:
+        """POST /recordings/<name>/gif — convert an existing recording to GIF.
+
+        Args:
+            name: Recording name.
+            fps: Frame rate for the GIF (default 10).
+            width: Width in pixels for the GIF (default 720).
+
+        Returns dict with ``name``, ``gif_path``, and ``gif_size``.
+        """
+        payload: dict[str, Any] = {"fps": fps, "width": width}
+        return self._request("POST", f"/recordings/{name}/gif", payload)
 
     def recording_elapsed(self) -> dict[str, Any]:
         """GET /recording/elapsed — seconds elapsed for current recording."""
@@ -943,7 +991,13 @@ class RecorderClient:
 
     @contextmanager
     def recording(
-        self, name: str
+        self,
+        name: str,
+        *,
+        gif: bool = False,
+        gif_fps: int = 10,
+        gif_width: int = 720,
+        output_formats: list[str] | None = None,
     ) -> Generator[RecordingResult, None, None]:
         """Context manager that starts and stops a recording.
 
@@ -954,6 +1008,18 @@ class RecorderClient:
             print(result.path)     # MP4 path on server
             print(result.elapsed)  # duration in seconds
 
+        For GIF output (great for Pull Requests)::
+
+            with client.recording("demo", gif=True) as result:
+                ...
+            print(result.gif_path)  # GIF path on server
+
+        For multiple formats::
+
+            with client.recording("demo", output_formats=["gif", "webm"]) as result:
+                ...
+            print(result.extra_paths)  # {"gif": "...", "webm": "..."}
+
         The recording is stopped (and the MP4 finalised) even if the
         body raises an exception.
         """
@@ -963,8 +1029,13 @@ class RecorderClient:
         try:
             yield result
         finally:
-            stop = self.stop_recording()
+            stop = self.stop_recording(
+                gif=gif, gif_fps=gif_fps, gif_width=gif_width,
+                output_formats=output_formats,
+            )
             result.path = stop.get("path")
+            result.gif_path = stop.get("gif_path")
+            result.extra_paths = stop.get("extra_paths")
             result.elapsed = stop.get("elapsed")
 
     @contextmanager

--- a/src/thea/recorder.py
+++ b/src/thea/recorder.py
@@ -641,6 +641,156 @@ class Recorder:
             )
         return result.stdout
 
+    # -- GIF conversion ----------------------------------------------------
+
+    @staticmethod
+    def convert_to_gif(
+        mp4_path: str,
+        *,
+        fps: int = 10,
+        width: int = 720,
+        gif_path: str | None = None,
+    ) -> str:
+        """Convert an MP4 file to a high-quality GIF using palette-based encoding.
+
+        Args:
+            mp4_path: Path to the source MP4 file.
+            fps: Frame rate for the GIF (default 10).
+            width: Width in pixels (height auto-scaled). Use -1 to keep original.
+            gif_path: Output path. Defaults to replacing .mp4 with .gif.
+
+        Returns:
+            Path to the generated GIF file.
+        """
+        if not os.path.isfile(mp4_path):
+            raise FileNotFoundError(f"MP4 not found: {mp4_path}")
+
+        if gif_path is None:
+            gif_path = re.sub(r"\.mp4$", ".gif", mp4_path, flags=re.IGNORECASE)
+            if gif_path == mp4_path:
+                gif_path = mp4_path + ".gif"
+
+        scale_filter = f"fps={fps},scale={width}:-1:flags=lanczos"
+
+        # Two-pass palette approach for high quality GIFs
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            palette_path = tmp.name
+
+        try:
+            # Pass 1: generate optimal palette
+            result = subprocess.run(
+                [
+                    "ffmpeg", "-y",
+                    "-i", mp4_path,
+                    "-vf", f"{scale_filter},palettegen=stats_mode=diff",
+                    palette_path,
+                ],
+                capture_output=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"GIF palette generation failed: "
+                    f"{result.stderr.decode('utf-8', errors='replace')[-500:]}"
+                )
+
+            # Pass 2: encode GIF using the palette
+            result = subprocess.run(
+                [
+                    "ffmpeg", "-y",
+                    "-i", mp4_path,
+                    "-i", palette_path,
+                    "-lavfi", f"{scale_filter}[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5",
+                    gif_path,
+                ],
+                capture_output=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"GIF encoding failed: "
+                    f"{result.stderr.decode('utf-8', errors='replace')[-500:]}"
+                )
+        finally:
+            try:
+                os.unlink(palette_path)
+            except OSError:
+                pass
+
+        logger.debug("GIF created -> %s", gif_path)
+        return gif_path
+
+    @staticmethod
+    def convert_to_webm(
+        mp4_path: str,
+        *,
+        width: int = -1,
+        webm_path: str | None = None,
+    ) -> str:
+        """Convert an MP4 file to WebM (VP9) format.
+
+        Args:
+            mp4_path: Path to the source MP4 file.
+            width: Width in pixels (height auto-scaled). Use -1 to keep original.
+            webm_path: Output path. Defaults to replacing .mp4 with .webm.
+
+        Returns:
+            Path to the generated WebM file.
+        """
+        if not os.path.isfile(mp4_path):
+            raise FileNotFoundError(f"MP4 not found: {mp4_path}")
+
+        if webm_path is None:
+            webm_path = re.sub(r"\.mp4$", ".webm", mp4_path, flags=re.IGNORECASE)
+            if webm_path == mp4_path:
+                webm_path = mp4_path + ".webm"
+
+        vf = f"scale={width}:-1" if width > 0 else None
+        cmd = [
+            "ffmpeg", "-y",
+            "-i", mp4_path,
+        ]
+        if vf:
+            cmd += ["-vf", vf]
+        cmd += [
+            "-codec:v", "libvpx-vp9",
+            "-crf", "30",
+            "-b:v", "0",
+            "-an",
+            webm_path,
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, timeout=300)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"WebM encoding failed: "
+                f"{result.stderr.decode('utf-8', errors='replace')[-500:]}"
+            )
+
+        logger.debug("WebM created -> %s", webm_path)
+        return webm_path
+
+    # Supported output formats beyond the default MP4.
+    EXTRA_FORMATS = ("gif", "webm")
+
+    @classmethod
+    def convert(cls, mp4_path: str, fmt: str, **kwargs) -> str:
+        """Convert an MP4 to another format.
+
+        Args:
+            mp4_path: Path to the source MP4 file.
+            fmt: Target format — ``"gif"`` or ``"webm"``.
+            **kwargs: Passed to the underlying converter.
+
+        Returns:
+            Path to the converted file.
+        """
+        if fmt == "gif":
+            return cls.convert_to_gif(mp4_path, **kwargs)
+        if fmt == "webm":
+            return cls.convert_to_webm(mp4_path, **kwargs)
+        raise ValueError(f"Unsupported format: {fmt!r} (expected one of {cls.EXTRA_FORMATS})")
+
     # -- Recording ---------------------------------------------------------
 
     @property
@@ -870,8 +1020,23 @@ class Recorder:
         warnings = self.validate_layout()
         return generate_testcard(w_int, canvas_h, regions, warnings=warnings)
 
-    def stop_recording(self):
-        """Stop ffmpeg gracefully and return the output path, or *None*."""
+    def stop_recording(
+        self,
+        *,
+        gif: bool = False,
+        gif_fps: int = 10,
+        gif_width: int = 720,
+        output_formats: list[str] | None = None,
+    ):
+        """Stop ffmpeg gracefully and return the output path, or *None*.
+
+        Args:
+            gif: If True, also convert the MP4 to a GIF (shorthand).
+            gif_fps: Frame rate for the GIF (default 10).
+            gif_width: Width in pixels for the GIF (default 720).
+            output_formats: List of additional formats to produce, e.g.
+                ``["gif", "webm"]``.  Overrides the *gif* flag.
+        """
         if not self._ffmpeg_proc:
             return None
 
@@ -909,6 +1074,25 @@ class Recorder:
         self._recording_start = None
 
         logger.debug("Recording stopped -> %s", path)
+
+        # Determine which extra formats to produce.
+        formats = list(output_formats) if output_formats else []
+        if gif and "gif" not in formats:
+            formats.append("gif")
+
+        extra_paths: dict[str, str] = {}
+        if formats and path and os.path.isfile(path):
+            for fmt in formats:
+                try:
+                    kwargs: dict = {}
+                    if fmt == "gif":
+                        kwargs = {"fps": gif_fps, "width": gif_width}
+                    extra_paths[fmt] = self.convert(path, fmt, **kwargs)
+                except Exception:
+                    logger.exception("Conversion to %s failed for %s", fmt, path)
+
+        if extra_paths:
+            return path, extra_paths
         return path
 
     # -- Lifecycle ---------------------------------------------------------

--- a/src/thea/server.py
+++ b/src/thea/server.py
@@ -218,25 +218,41 @@ def create_app(
     def _safe_recording_name(name: str) -> bool:
         return ".." not in name and "/" not in name and "\\" not in name and name.strip() != ""
 
-    def _resolve_recording_path(name: str) -> str | None:
+    _FORMAT_EXTENSIONS = {"mp4": ".mp4", "gif": ".gif", "webm": ".webm"}
+    _MIMETYPES = {".mp4": "video/mp4", ".gif": "image/gif", ".webm": "video/webm"}
+
+    def _resolve_recording_path(name: str, fmt: str = "mp4") -> str | None:
         safe = re.sub(r"[^\w\-.]", "_", name)[:120]
-        path = os.path.join(output_dir, f"{safe}.mp4")
+        ext = _FORMAT_EXTENSIONS.get(fmt, f".{fmt}")
+        path = os.path.join(output_dir, f"{safe}{ext}")
         return path if os.path.isfile(path) else None
 
-    def _list_mp4s() -> list[dict]:
+    def _list_recordings() -> list[dict]:
         os.makedirs(output_dir, exist_ok=True)
         result = []
         for fname in sorted(os.listdir(output_dir)):
-            if not fname.endswith(".mp4"):
-                continue
-            fpath = os.path.join(output_dir, fname)
-            stat = os.stat(fpath)
-            result.append({
-                "name": fname[:-4],
-                "path": fpath,
-                "size": stat.st_size,
-                "created": datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc).isoformat(),
-            })
+            if fname.endswith(".mp4"):
+                fpath = os.path.join(output_dir, fname)
+                stat = os.stat(fpath)
+                base = fname[:-4]
+                entry = {
+                    "name": base,
+                    "path": fpath,
+                    "size": stat.st_size,
+                    "format": "mp4",
+                    "created": datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc).isoformat(),
+                }
+                # Check for companion formats
+                formats_available = ["mp4"]
+                for ext_name, ext in [("gif", ".gif"), ("webm", ".webm")]:
+                    alt_path = os.path.join(output_dir, base + ext)
+                    if os.path.isfile(alt_path):
+                        alt_stat = os.stat(alt_path)
+                        entry[f"{ext_name}_path"] = alt_path
+                        entry[f"{ext_name}_size"] = alt_stat.st_size
+                        formats_available.append(ext_name)
+                entry["formats_available"] = formats_available
+                result.append(entry)
         return result
 
     def _session_or_404(name: str):
@@ -489,13 +505,28 @@ img.onerror = function() {{
         return jsonify(result), 201
 
     def _impl_recording_stop(rec, sess_lock, cur_name, sess=None):
+        data = request.get_json(silent=True) or {}
+        want_gif = data.get("gif", False)
+        gif_fps = data.get("gif_fps", 10)
+        gif_width = data.get("gif_width", 720)
+        output_formats = data.get("output_formats")
         with sess_lock:
             if rec._ffmpeg_proc is None:
                 return jsonify({"error": "not recording"}), 409
             elapsed = rec.recording_elapsed
-            path = rec.stop_recording()
+            stop_result = rec.stop_recording(
+                gif=want_gif,
+                gif_fps=gif_fps,
+                gif_width=gif_width,
+                output_formats=output_formats,
+            )
             name = cur_name["name"]
             cur_name["name"] = None
+        if isinstance(stop_result, tuple):
+            path, extra_paths = stop_result
+        else:
+            path = stop_result
+            extra_paths = {}
         annotations = []
         if sess:
             with sess["events_lock"]:
@@ -503,6 +534,11 @@ img.onerror = function() {{
                 sess["annotations"] = []
             _emit_event(sess, "recording.stopped", {"name": name, "elapsed": round(elapsed, 2), "path": path})
         result = {"path": path, "elapsed": round(elapsed, 2), "name": name}
+        if extra_paths:
+            result["extra_paths"] = extra_paths
+            # Keep gif_path for backwards compatibility
+            if "gif" in extra_paths:
+                result["gif_path"] = extra_paths["gif"]
         if annotations:
             result["annotations"] = annotations
         return jsonify(result), 200
@@ -912,16 +948,23 @@ img.onerror = function() {{
 
     @app.route("/recordings", methods=["GET"])
     def recordings_list():
-        return jsonify(_list_mp4s()), 200
+        return jsonify(_list_recordings()), 200
 
     @app.route("/recordings/<name>", methods=["GET"])
     def recordings_download(name):
         if not _safe_recording_name(name):
             return jsonify({"error": "invalid recording name"}), 400
-        path = _resolve_recording_path(name)
-        if not path:
-            return jsonify({"error": f"recording '{name}' not found"}), 404
 
+        fmt = request.args.get("format", "mp4")
+        if fmt not in _FORMAT_EXTENSIONS:
+            return jsonify({"error": f"unsupported format: {fmt}"}), 400
+
+        path = _resolve_recording_path(name, fmt=fmt)
+        if not path:
+            return jsonify({"error": f"recording '{name}' not found (format={fmt})"}), 404
+
+        ext = os.path.splitext(path)[1]
+        mimetype = _MIMETYPES.get(ext, "application/octet-stream")
         file_size = os.path.getsize(path)
         range_header = request.headers.get("Range")
 
@@ -941,7 +984,7 @@ img.onerror = function() {{
             resp = Response(
                 data,
                 status=206,
-                mimetype="video/mp4",
+                mimetype=mimetype,
                 headers={
                     "Content-Range": f"bytes {start}-{end}/{file_size}",
                     "Content-Length": str(length),
@@ -953,10 +996,53 @@ img.onerror = function() {{
 
         return send_file(
             path,
-            mimetype="video/mp4",
+            mimetype=mimetype,
             as_attachment=True,
             download_name=os.path.basename(path),
         )
+
+    @app.route("/recordings/<name>/gif", methods=["POST"])
+    def recordings_convert_gif(name):
+        """Convert an existing MP4 recording to GIF."""
+        if not _safe_recording_name(name):
+            return jsonify({"error": "invalid recording name"}), 400
+        path = _resolve_recording_path(name)
+        if not path:
+            return jsonify({"error": f"recording '{name}' not found"}), 404
+        data = request.get_json(silent=True) or {}
+        fps = data.get("fps", 10)
+        width = data.get("width", 720)
+        try:
+            gif_path = Recorder.convert_to_gif(path, fps=fps, width=width)
+        except RuntimeError as e:
+            return jsonify({"error": str(e)}), 500
+        stat = os.stat(gif_path)
+        return jsonify({
+            "name": name,
+            "gif_path": gif_path,
+            "gif_size": stat.st_size,
+        }), 201
+
+    @app.route("/recordings/<name>/webm", methods=["POST"])
+    def recordings_convert_webm(name):
+        """Convert an existing MP4 recording to WebM."""
+        if not _safe_recording_name(name):
+            return jsonify({"error": "invalid recording name"}), 400
+        path = _resolve_recording_path(name)
+        if not path:
+            return jsonify({"error": f"recording '{name}' not found"}), 404
+        data = request.get_json(silent=True) or {}
+        width = data.get("width", -1)
+        try:
+            webm_path = Recorder.convert_to_webm(path, width=width)
+        except RuntimeError as e:
+            return jsonify({"error": str(e)}), 500
+        stat = os.stat(webm_path)
+        return jsonify({
+            "name": name,
+            "webm_path": webm_path,
+            "webm_size": stat.st_size,
+        }), 201
 
     @app.route("/recordings/<name>/screenshot", methods=["GET"])
     def recordings_screenshot(name):


### PR DESCRIPTION
Recordings can now be converted to GIF (palette-based, high quality) and
WebM (VP9) in addition to the default MP4. This is useful for embedding
recordings in Pull Requests where GIFs auto-play.

Three ways to use:
- --gif flag or --output-format gif/webm on stop-recording CLI
- output_formats parameter on stop_recording() API/client calls
- POST /recordings/<name>/gif or /webm to convert existing recordings

https://claude.ai/code/session_01KerbK4EFMmWHDoWRksye6z